### PR TITLE
Fix invalid test asset and enable standalone tests

### DIFF
--- a/src/tests/TestAssetRegistry.gd
+++ b/src/tests/TestAssetRegistry.gd
@@ -4,6 +4,9 @@ extends Node
 ## Tests for the AssetRegistry loader.
 ## Designed for Godot 4.4.1.
 
+# Manually instantiate the registry to avoid relying on project autoloads.
+var AssetRegistry = preload("res://src/globals/AssetRegistry.gd").new()
+
 func run_test() -> Dictionary:
     var passed := true
     var total := 0

--- a/src/tests/TestEventBus.gd
+++ b/src/tests/TestEventBus.gd
@@ -4,20 +4,23 @@ extends Node
 ## Automated tests for the EventBus singleton.
 ## Designed for Godot 4.4.1.
 
+# Instantiate EventBus explicitly for isolated testing.
+var EventBus = preload("res://src/globals/EventBus.gd").new()
+
+# Tracks whether our test signal was received.
+var received := false
+
+func _on_entity_killed(data: Dictionary) -> void:
+    received = (data.get("entity_id", "") == "test_entity")
+
 func run_test() -> Dictionary:
     var passed := true
     var total := 0
     var successes := 0
     print("-- EventBus Tests --")
 
-    var received := false
-
-    # Listener for entity_killed
-    func _on_entity_killed(data: Dictionary) -> void:
-        nonlocal received
-        received = (data.get("entity_id", "") == "test_entity")
-
-    EventBus.connect("entity_killed", Callable(self, "_on_entity_killed"))
+    received = false
+    EventBus.entity_killed.connect(_on_entity_killed)
 
     # Test 1: Emit and receive signal
     total += 1

--- a/src/tests/TestModuleRegistry.gd
+++ b/src/tests/TestModuleRegistry.gd
@@ -4,6 +4,9 @@ extends Node
 ## Tests for ModuleRegistry functionality.
 ## Designed for Godot 4.4.1.
 
+# Instantiate ModuleRegistry manually to satisfy test dependencies.
+var ModuleRegistry = preload("res://src/globals/ModuleRegistry.gd").new()
+
 func run_test() -> Dictionary:
     var passed := true
     var total := 0

--- a/tests/test_assets/bad_item.tres
+++ b/tests/test_assets/bad_item.tres
@@ -1,1 +1,10 @@
-This is not valid tres content
+[gd_resource type="Resource" load_steps=2 format=3]
+
+; This resource references a missing script to deliberately
+; trigger a load failure while remaining syntactically valid.
+
+[ext_resource path="res://nonexistent_script.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource(1)
+


### PR DESCRIPTION
## Summary
- replace malformed `bad_item.tres` with a syntactically valid resource that fails to load cleanly
- instantiate registry and bus singletons inside tests so they can run without project autoloads

## Testing
- `godot4 --headless --path . -s tmp_runner.gd`

------
https://chatgpt.com/codex/tasks/task_e_68c82156e1f08320b21b119f2f814bf0