### PR TITLE
Add headless validation scene with TestDummy entity

### DIFF
--- a/src/tests/TestDummyEntity.gd
+++ b/src/tests/TestDummyEntity.gd
@@ -1,0 +1,11 @@
+extends Node
+class_name TestDummyEntity
+
+## Test harness node that exposes entity data for validation scenes.
+## Designed for Godot 4.4.1.
+
+@export var entity_data: EntityData
+
+func _ready() -> void:
+    ## Registers the node into the global 'entities' group for system processing.
+    add_to_group("entities")

--- a/src/tests/TestDummyEntity.gd.uid
+++ b/src/tests/TestDummyEntity.gd.uid
@@ -1,0 +1,1 @@
+uid://2hrbjue2mwgn

--- a/tests/Sprint1_Validation.tscn
+++ b/tests/Sprint1_Validation.tscn
@@ -1,13 +1,14 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=4 format=3]
 
-[ext_resource path="res://src/core/EntityData.gd" type="Script" id=1]
+[ext_resource path="res://src/tests/TestDummyEntity.gd" type="Script" id=1]
 [ext_resource path="res://src/systems/DebugSystem.gd" type="Script" id=2]
+[ext_resource path="res://tests/test_assets/TestDummy.tres" type="EntityData" id=3]
 
 [node name="Root" type="Node"]
 
 [node name="TestEntity" type="Node" parent="."]
 script = ExtResource(1)
-groups = ["entities"]
+entity_data = ExtResource(3)
 
 [node name="DebugSystem" type="Node" parent="."]
 script = ExtResource(2)

--- a/tests/test_assets/TestDummy.tres
+++ b/tests/test_assets/TestDummy.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" load_steps=3 format=3]
+[ext_resource path="res://src/core/EntityData.gd" type="Script" id=1]
+[ext_resource path="res://tests/test_assets/TestDummyStats.tres" type="Resource" id=2]
+
+[resource]
+script = ExtResource(1)
+entity_id = "test_dummy"
+display_name = "Test Dummy"
+entity_type = 0
+archetype_id = "test_dummy"
+components = {
+    "stats": ExtResource(2)
+}

--- a/tests/test_assets/TestDummyStats.tres
+++ b/tests/test_assets/TestDummyStats.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+[ext_resource path="res://src/systems/StatsComponent.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource(1)
+health = 100
+action_points = 0


### PR DESCRIPTION
## Summary
- Add StatsComponent and EntityData test resources to validate ECS components
- Create TestDummyEntity script and update Sprint1_Validation scene for headless testing

## Testing
- `godot4 --headless --path . --quit tests/Sprint1_Validation.tscn`


------
https://chatgpt.com/codex/tasks/task_e_68c82a8991e48320adb0c093b6c9fd21