### PR TITLE
Add editor UI for running headless tests

### DIFF
--- a/addons/test_runner_gui/README.md
+++ b/addons/test_runner_gui/README.md
@@ -1,0 +1,19 @@
+# Test Runner GUI
+
+This editor plugin exposes a dock inside the Godot editor that wraps `tests/Test_runner.gd`.
+It allows developers to run the headless test suite without leaving editor mode.
+
+## Features
+- Fields for every command-line flag supported by `Test_runner.gd`.
+- Runs the suite using the current Godot executable in headless mode.
+- Displays verbose output and exit code in a read-only panel.
+
+## Usage
+1. Enable **Test Runner GUI** in *Project > Project Settings > Plugins*.
+2. A *Test Runner* dock will appear on the right side of the editor.
+3. Configure desired flags and press **Run Tests**.
+4. Results from the headless process appear in the output box.
+
+The plugin invokes the same binary running the editor with the `--headless` flag and
+executes `tests/Test_runner.gd` within the project path. Ensure a compatible Godot
+console binary is available in your environment.

--- a/addons/test_runner_gui/TestRunnerDock.gd
+++ b/addons/test_runner_gui/TestRunnerDock.gd
@@ -1,0 +1,51 @@
+extends VBoxContainer
+class_name TestRunnerDock
+
+@onready var output_box: TextEdit = $Output
+@onready var options: GridContainer = $Options
+
+func _ready() -> void:
+    $RunButton.pressed.connect(_on_run_pressed)
+
+func _on_run_pressed() -> void:
+    output_box.text = ""
+    var args: PackedStringArray = []
+    if options.get_node("NoColor").button_pressed:
+        args.append("--no-color")
+    var out_dir := options.get_node("OutDir").text.strip_edges()
+    if out_dir != "":
+        args.append_array(["--out-dir", out_dir])
+    if options.get_node("NoJson").button_pressed:
+        args.append("--no-json")
+    if options.get_node("NoXml").button_pressed:
+        args.append("--no-xml")
+    if options.get_node("Simple").button_pressed:
+        args.append("--simple")
+    var batch_size := int(options.get_node("BatchSize").value)
+    if batch_size > 0:
+        args.append_array(["--batch-size", str(batch_size)])
+    var slow := int(options.get_node("Slow").value)
+    args.append_array(["--slow", str(slow)])
+    var retries := int(options.get_node("Retries").value)
+    if retries > 0:
+        args.append_array(["--retries", str(retries)])
+    var tags := options.get_node("Tags").text.strip_edges()
+    if tags != "":
+        args.append_array(["--tags", tags])
+    var skip := options.get_node("Skip").text.strip_edges()
+    if skip != "":
+        args.append_array(["--skip", skip])
+    var pri := options.get_node("Priority").text.strip_edges()
+    if pri != "":
+        args.append_array(["--priority", pri])
+    var owner := options.get_node("Owner").text.strip_edges()
+    if owner != "":
+        args.append_array(["--owner", owner])
+
+    var exe_path := OS.get_executable_path()
+    var cmd_args: PackedStringArray = ["--headless", "--path", ProjectSettings.globalize_path("res://"), "-s", "tests/Test_runner.gd"]
+    cmd_args.append_array(args)
+    var output: Array = []
+    var code := OS.execute(exe_path, cmd_args, output, true)
+    output_box.text = "\n".join(output)
+    output_box.append_text("\nExit code: %d" % code)

--- a/addons/test_runner_gui/TestRunnerDock.tscn
+++ b/addons/test_runner_gui/TestRunnerDock.tscn
@@ -1,0 +1,76 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://addons/test_runner_gui/TestRunnerDock.gd" type="Script" id=1]
+
+[node name="TestRunnerDock" type="VBoxContainer"]
+script = ExtResource(1)
+size_flags_vertical = 3
+
+[node name="Options" type="GridContainer" parent="."]
+columns = 2
+
+[node name="NoColor" type="CheckBox" parent="Options"]
+text = "No Color (--no-color)"
+
+[node name="OutDirLabel" type="Label" parent="Options"]
+text = "Output Dir (--out-dir)"
+
+[node name="OutDir" type="LineEdit" parent="Options"/]
+
+[node name="NoJson" type="CheckBox" parent="Options"]
+text = "No JSON (--no-json)"
+
+[node name="NoXml" type="CheckBox" parent="Options"]
+text = "No XML (--no-xml)"
+
+[node name="Simple" type="CheckBox" parent="Options"]
+text = "Simple (--simple)"
+
+[node name="BatchSizeLabel" type="Label" parent="Options"]
+text = "Batch Size (--batch-size)"
+
+[node name="BatchSize" type="SpinBox" parent="Options"]
+min_value = 0
+max_value = 1000
+
+[node name="SlowLabel" type="Label" parent="Options"]
+text = "Slow Threshold (--slow)"
+
+[node name="Slow" type="SpinBox" parent="Options"]
+min_value = 0
+max_value = 10000
+value = 5
+
+[node name="RetriesLabel" type="Label" parent="Options"]
+text = "Retries (--retries)"
+
+[node name="Retries" type="SpinBox" parent="Options"]
+min_value = 0
+max_value = 10
+
+[node name="TagsLabel" type="Label" parent="Options"]
+text = "Tags (--tags)"
+
+[node name="Tags" type="LineEdit" parent="Options"/]
+
+[node name="SkipLabel" type="Label" parent="Options"]
+text = "Skip (--skip)"
+
+[node name="Skip" type="LineEdit" parent="Options"/]
+
+[node name="PriorityLabel" type="Label" parent="Options"]
+text = "Priority (--priority)"
+
+[node name="Priority" type="LineEdit" parent="Options"/]
+
+[node name="OwnerLabel" type="Label" parent="Options"]
+text = "Owner (--owner)"
+
+[node name="Owner" type="LineEdit" parent="Options"/]
+
+[node name="RunButton" type="Button" parent="."]
+text = "Run Tests"
+
+[node name="Output" type="TextEdit" parent="."]
+read_only = true
+v_size_flags = 3

--- a/addons/test_runner_gui/plugin.cfg
+++ b/addons/test_runner_gui/plugin.cfg
@@ -1,0 +1,6 @@
+[plugin]
+name="Test Runner GUI"
+description="Run tests via Test_runner.gd from the editor"
+author="Glevel3"
+version="1.0"
+script="test_runner_gui.gd"

--- a/addons/test_runner_gui/test_runner_gui.gd
+++ b/addons/test_runner_gui/test_runner_gui.gd
@@ -1,0 +1,12 @@
+extends EditorPlugin
+
+var dock: Control
+
+func _enter_tree() -> void:
+    dock = load("res://addons/test_runner_gui/TestRunnerDock.tscn").instantiate()
+    add_control_to_dock(DOCK_SLOT_RIGHT_UL, dock)
+
+func _exit_tree() -> void:
+    if dock:
+        remove_control_from_docks(dock)
+        dock.free()


### PR DESCRIPTION
## Summary
- add `Test Runner GUI` editor plugin with docked interface
- expose all Test_runner.gd flags as form fields and show verbose output

## Testing
- `godot --headless --path . -s tests/Test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c833cc77948320b92e33ebfb2f617e