### PR TITLE
Improve EventBus singleton access

### DIFF
--- a/src/systems/DebugSystem.gd
+++ b/src/systems/DebugSystem.gd
@@ -1,14 +1,19 @@
 extends "res://src/systems/System.gd"
 class_name DebugSystem
 
+const EVENT_BUS_SCRIPT := preload("res://src/globals/EventBus.gd")
+
 const EntityData = preload("res://src/core/EntityData.gd")
 const StatsComponent = preload("res://src/systems/StatsComponent.gd")
 
 ## Optional EventBus reference to allow dependency injection in tests.
-var event_bus: Node = null
+var event_bus: EventBus = null
 
 ## Simple system that prints entity statistics to the console each physics frame.
 ## Designed for Godot 4.4.1.
+
+func _ready() -> void:
+    _ensure_event_bus_subscription()
 
 func _physics_process(delta: float) -> void:
     for entity in get_tree().get_nodes_in_group("entities"):
@@ -26,9 +31,61 @@ func _physics_process(delta: float) -> void:
                     }
                 )
 
+func _ensure_event_bus_subscription() -> void:
+    if event_bus and _connect_event_bus(event_bus):
+        return
+
+    if typeof(EventBus) == TYPE_OBJECT and EventBus is Node:
+        event_bus = EventBus
+        var error := EventBus.connect(
+            "entity_killed",
+            Callable(self, "_on_entity_killed"),
+            Object.CONNECT_REFERENCE_COUNTED,
+        )
+        if error != OK and error != ERR_ALREADY_IN_USE:
+            push_warning("DebugSystem failed to connect to EventBus.entity_killed (error %d)." % error)
+        return
+
+    if EVENT_BUS_SCRIPT.is_singleton_ready():
+        event_bus = EVENT_BUS_SCRIPT.get_singleton()
+        if _connect_event_bus(event_bus):
+            return
+
+    var resolved_bus := _get_event_bus()
+    if resolved_bus:
+        event_bus = resolved_bus
+        _connect_event_bus(event_bus)
+
+func _connect_event_bus(bus: Node) -> bool:
+    if not is_instance_valid(bus):
+        return false
+
+    if not bus.has_signal("entity_killed"):
+        push_warning("EventBus reference missing entity_killed signal; cannot subscribe.")
+        return false
+
+    var error := bus.connect(
+        "entity_killed",
+        Callable(self, "_on_entity_killed"),
+        Object.CONNECT_REFERENCE_COUNTED,
+    )
+    if error != OK and error != ERR_ALREADY_IN_USE:
+        push_warning("DebugSystem failed to connect to entity_killed (error %d)." % error)
+        return false
+
+    return true
+
 ## Attempts to locate the global EventBus if it was not injected manually.
 func _get_event_bus() -> Node:
     if event_bus:
+        return event_bus
+
+    if EVENT_BUS_SCRIPT.is_singleton_ready():
+        event_bus = EVENT_BUS_SCRIPT.get_singleton()
+        return event_bus
+
+    if typeof(EventBus) == TYPE_OBJECT and EventBus is Node:
+        event_bus = EventBus
         return event_bus
 
     var tree := get_tree()
@@ -50,3 +107,12 @@ func _snapshot_stats(stats: StatsComponent) -> Dictionary:
         "health": stats.health,
         "action_points": stats.action_points,
     }
+
+## Receives notifications when other systems broadcast entity_killed.
+## The payload is retained for future diagnostics or extended instrumentation.
+func _on_entity_killed(payload: Dictionary) -> void:
+    if not payload.has("entity_id"):
+        return
+
+    var entity_id := payload["entity_id"]
+    print("DebugSystem observed entity_killed for %s" % str(entity_id))

--- a/src/systems/System.gd
+++ b/src/systems/System.gd
@@ -1,6 +1,8 @@
 extends Node
 class_name System
 
+const EVENT_BUS_SCRIPT := preload("res://src/globals/EventBus.gd")
+
 ## Abstract base class for gameplay systems that operate on entities.
 ## Systems are expected to iterate over entities each frame and perform logic.
 ## Systems must stay decoupled from each other – use emit_event()/subscribe_event()
@@ -44,6 +46,12 @@ func subscribe_event(signal_name: StringName, callback: Callable, flags: int = O
 ## Internal helper that fetches the EventBus autoload or returns null when the
 ## system is running outside of a full game tree (e.g. during isolated tests).
 func _get_event_bus() -> Node:
+    if EVENT_BUS_SCRIPT.is_singleton_ready():
+        return EVENT_BUS_SCRIPT.get_singleton()
+
+    if typeof(EventBus) == TYPE_OBJECT and EventBus is Node:
+        return EventBus
+
     var scene_tree := get_tree()
     if scene_tree == null:
         return null


### PR DESCRIPTION
## Summary
- store the EventBus autoload instance in a static singleton slot and expose helpers that avoid scene-tree lookups while keeping payload validation
- let System and DebugSystem resolve the EventBus through the new singleton helpers and connect DebugSystem directly to the global entity_killed signal
- add a diagnostic handler in DebugSystem so the entity_killed connection can log observed kills

## Testing
- `godot4 --headless --path /workspace/Glevel3 --quit` *(fails: project has no main scene defined)*
- `godot4 --headless --path /workspace/Glevel3 --script res://src/tests/TestEventBus.gd` *(fails: script does not inherit from SceneTree/MainLoop so Godot refuses to start it directly)*

------
https://chatgpt.com/codex/tasks/task_e_68c8665db3188320a17dd2b0c693db28