### PR TITLE
Add scroll container to EventBus harness UI

### DIFF
--- a/tests/EventBus_TestHarness.tscn
+++ b/tests/EventBus_TestHarness.tscn
@@ -20,224 +20,233 @@ offset_top = 24.0
 offset_right = -24.0
 offset_bottom = -24.0
 
-[node name="VBox" type="VBoxContainer" parent="Margin"]
+[node name="Scroll" type="ScrollContainer" parent="Margin"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = 0.0
+offset_bottom = 0.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="VBox" type="VBoxContainer" parent="Margin/Scroll"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Title" type="Label" parent="Margin/VBox"]
+[node name="Title" type="Label" parent="Margin/Scroll/VBox"]
 text = "Event Bus Test Harness"
 
-[node name="Instructions" type="Label" parent="Margin/VBox"]
+[node name="Instructions" type="Label" parent="Margin/Scroll/VBox"]
 text = "Enter payload data for each signal and press the corresponding emit button.\nThe Test Listener logs every event below."
 autowrap_mode = 3
 
-[node name="Separator1" type="HSeparator" parent="Margin/VBox"]
+[node name="Separator1" type="HSeparator" parent="Margin/Scroll/VBox"]
 
-[node name="DebugStatsReportedSection" type="VBoxContainer" parent="Margin/VBox"]
+[node name="DebugStatsReportedSection" type="VBoxContainer" parent="Margin/Scroll/VBox"]
 
-[node name="DebugStatsReportedLabel" type="Label" parent="Margin/VBox/DebugStatsReportedSection"]
+[node name="DebugStatsReportedLabel" type="Label" parent="Margin/Scroll/VBox/DebugStatsReportedSection"]
 text = "debug_stats_reported"
 
-[node name="DebugStatsReportedFields" type="GridContainer" parent="Margin/VBox/DebugStatsReportedSection"]
+[node name="DebugStatsReportedFields" type="GridContainer" parent="Margin/Scroll/VBox/DebugStatsReportedSection"]
 columns = 2
 
-[node name="DebugStatsEntityIdLabel" type="Label" parent="Margin/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
+[node name="DebugStatsEntityIdLabel" type="Label" parent="Margin/Scroll/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
 text = "entity_id"
 
-[node name="DebugStatsEntityId" type="LineEdit" parent="Margin/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
+[node name="DebugStatsEntityId" type="LineEdit" parent="Margin/Scroll/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "entity_id"
 
-[node name="DebugStatsStatsLabel" type="Label" parent="Margin/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
+[node name="DebugStatsStatsLabel" type="Label" parent="Margin/Scroll/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
 text = "stats"
 
-[node name="DebugStatsStats" type="LineEdit" parent="Margin/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
+[node name="DebugStatsStats" type="LineEdit" parent="Margin/Scroll/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "{\"health\": 100, \"action_points\": 10}"
 
-[node name="DebugStatsTimestampLabel" type="Label" parent="Margin/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
+[node name="DebugStatsTimestampLabel" type="Label" parent="Margin/Scroll/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
 text = "timestamp (optional)"
 
-[node name="DebugStatsTimestamp" type="LineEdit" parent="Margin/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
+[node name="DebugStatsTimestamp" type="LineEdit" parent="Margin/Scroll/VBox/DebugStatsReportedSection/DebugStatsReportedFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "e.g. 1234.56"
 
-[node name="DebugStatsEmitButton" type="Button" parent="Margin/VBox/DebugStatsReportedSection"]
+[node name="DebugStatsEmitButton" type="Button" parent="Margin/Scroll/VBox/DebugStatsReportedSection"]
 unique_name_in_owner = true
 text = "Emit debug_stats_reported"
 
-[node name="SeparatorDebugStats" type="HSeparator" parent="Margin/VBox"]
+[node name="SeparatorDebugStats" type="HSeparator" parent="Margin/Scroll/VBox"]
 
-[node name="EntityKilledSection" type="VBoxContainer" parent="Margin/VBox"]
+[node name="EntityKilledSection" type="VBoxContainer" parent="Margin/Scroll/VBox"]
 
-[node name="EntityKilledLabel" type="Label" parent="Margin/VBox/EntityKilledSection"]
+[node name="EntityKilledLabel" type="Label" parent="Margin/Scroll/VBox/EntityKilledSection"]
 text = "entity_killed"
 
-[node name="EntityKilledFields" type="GridContainer" parent="Margin/VBox/EntityKilledSection"]
+[node name="EntityKilledFields" type="GridContainer" parent="Margin/Scroll/VBox/EntityKilledSection"]
 columns = 2
 
-[node name="EntityKilledEntityIdLabel" type="Label" parent="Margin/VBox/EntityKilledSection/EntityKilledFields"]
+[node name="EntityKilledEntityIdLabel" type="Label" parent="Margin/Scroll/VBox/EntityKilledSection/EntityKilledFields"]
 text = "entity_id"
 
-[node name="EntityKilledEntityId" type="LineEdit" parent="Margin/VBox/EntityKilledSection/EntityKilledFields"]
+[node name="EntityKilledEntityId" type="LineEdit" parent="Margin/Scroll/VBox/EntityKilledSection/EntityKilledFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "entity_id"
 
-[node name="EntityKilledKillerIdLabel" type="Label" parent="Margin/VBox/EntityKilledSection/EntityKilledFields"]
+[node name="EntityKilledKillerIdLabel" type="Label" parent="Margin/Scroll/VBox/EntityKilledSection/EntityKilledFields"]
 text = "killer_id"
 
-[node name="EntityKilledKillerId" type="LineEdit" parent="Margin/VBox/EntityKilledSection/EntityKilledFields"]
+[node name="EntityKilledKillerId" type="LineEdit" parent="Margin/Scroll/VBox/EntityKilledSection/EntityKilledFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "killer_id"
 
-[node name="EntityKilledArchetypeIdLabel" type="Label" parent="Margin/VBox/EntityKilledSection/EntityKilledFields"]
+[node name="EntityKilledArchetypeIdLabel" type="Label" parent="Margin/Scroll/VBox/EntityKilledSection/EntityKilledFields"]
 text = "archetype_id (optional)"
 
-[node name="EntityKilledArchetypeId" type="LineEdit" parent="Margin/VBox/EntityKilledSection/EntityKilledFields"]
+[node name="EntityKilledArchetypeId" type="LineEdit" parent="Margin/Scroll/VBox/EntityKilledSection/EntityKilledFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "archetype_id"
 
-[node name="EntityKilledEntityTypeLabel" type="Label" parent="Margin/VBox/EntityKilledSection/EntityKilledFields"]
+[node name="EntityKilledEntityTypeLabel" type="Label" parent="Margin/Scroll/VBox/EntityKilledSection/EntityKilledFields"]
 text = "entity_type (optional)"
 
-[node name="EntityKilledEntityType" type="LineEdit" parent="Margin/VBox/EntityKilledSection/EntityKilledFields"]
+[node name="EntityKilledEntityType" type="LineEdit" parent="Margin/Scroll/VBox/EntityKilledSection/EntityKilledFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "entity_type"
 
-[node name="EntityKilledComponentsLabel" type="Label" parent="Margin/VBox/EntityKilledSection/EntityKilledFields"]
+[node name="EntityKilledComponentsLabel" type="Label" parent="Margin/Scroll/VBox/EntityKilledSection/EntityKilledFields"]
 text = "components (optional)"
 
-[node name="EntityKilledComponents" type="LineEdit" parent="Margin/VBox/EntityKilledSection/EntityKilledFields"]
+[node name="EntityKilledComponents" type="LineEdit" parent="Margin/Scroll/VBox/EntityKilledSection/EntityKilledFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "{\"stats\": {\"health\": 0}}"
 
-[node name="EntityKilledEmitButton" type="Button" parent="Margin/VBox/EntityKilledSection"]
+[node name="EntityKilledEmitButton" type="Button" parent="Margin/Scroll/VBox/EntityKilledSection"]
 unique_name_in_owner = true
 text = "Emit entity_killed"
 
-[node name="Separator2" type="HSeparator" parent="Margin/VBox"]
+[node name="Separator2" type="HSeparator" parent="Margin/Scroll/VBox"]
 
-[node name="ItemAcquiredSection" type="VBoxContainer" parent="Margin/VBox"]
+[node name="ItemAcquiredSection" type="VBoxContainer" parent="Margin/Scroll/VBox"]
 
-[node name="ItemAcquiredLabel" type="Label" parent="Margin/VBox/ItemAcquiredSection"]
+[node name="ItemAcquiredLabel" type="Label" parent="Margin/Scroll/VBox/ItemAcquiredSection"]
 text = "item_acquired"
 
-[node name="ItemAcquiredFields" type="GridContainer" parent="Margin/VBox/ItemAcquiredSection"]
+[node name="ItemAcquiredFields" type="GridContainer" parent="Margin/Scroll/VBox/ItemAcquiredSection"]
 columns = 2
 
-[node name="ItemAcquiredItemIdLabel" type="Label" parent="Margin/VBox/ItemAcquiredSection/ItemAcquiredFields"]
+[node name="ItemAcquiredItemIdLabel" type="Label" parent="Margin/Scroll/VBox/ItemAcquiredSection/ItemAcquiredFields"]
 text = "item_id"
 
-[node name="ItemAcquiredItemId" type="LineEdit" parent="Margin/VBox/ItemAcquiredSection/ItemAcquiredFields"]
+[node name="ItemAcquiredItemId" type="LineEdit" parent="Margin/Scroll/VBox/ItemAcquiredSection/ItemAcquiredFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "item_id"
 
-[node name="ItemAcquiredQuantityLabel" type="Label" parent="Margin/VBox/ItemAcquiredSection/ItemAcquiredFields"]
+[node name="ItemAcquiredQuantityLabel" type="Label" parent="Margin/Scroll/VBox/ItemAcquiredSection/ItemAcquiredFields"]
 text = "quantity"
 
-[node name="ItemAcquiredQuantity" type="LineEdit" parent="Margin/VBox/ItemAcquiredSection/ItemAcquiredFields"]
+[node name="ItemAcquiredQuantity" type="LineEdit" parent="Margin/Scroll/VBox/ItemAcquiredSection/ItemAcquiredFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "quantity"
 
-[node name="ItemAcquiredOwnerIdLabel" type="Label" parent="Margin/VBox/ItemAcquiredSection/ItemAcquiredFields"]
+[node name="ItemAcquiredOwnerIdLabel" type="Label" parent="Margin/Scroll/VBox/ItemAcquiredSection/ItemAcquiredFields"]
 text = "owner_id (optional)"
 
-[node name="ItemAcquiredOwnerId" type="LineEdit" parent="Margin/VBox/ItemAcquiredSection/ItemAcquiredFields"]
+[node name="ItemAcquiredOwnerId" type="LineEdit" parent="Margin/Scroll/VBox/ItemAcquiredSection/ItemAcquiredFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "owner_id"
 
-[node name="ItemAcquiredSourceLabel" type="Label" parent="Margin/VBox/ItemAcquiredSection/ItemAcquiredFields"]
+[node name="ItemAcquiredSourceLabel" type="Label" parent="Margin/Scroll/VBox/ItemAcquiredSection/ItemAcquiredFields"]
 text = "source (optional)"
 
-[node name="ItemAcquiredSource" type="LineEdit" parent="Margin/VBox/ItemAcquiredSection/ItemAcquiredFields"]
+[node name="ItemAcquiredSource" type="LineEdit" parent="Margin/Scroll/VBox/ItemAcquiredSection/ItemAcquiredFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "source"
 
-[node name="ItemAcquiredMetadataLabel" type="Label" parent="Margin/VBox/ItemAcquiredSection/ItemAcquiredFields"]
+[node name="ItemAcquiredMetadataLabel" type="Label" parent="Margin/Scroll/VBox/ItemAcquiredSection/ItemAcquiredFields"]
 text = "metadata (optional)"
 
-[node name="ItemAcquiredMetadata" type="LineEdit" parent="Margin/VBox/ItemAcquiredSection/ItemAcquiredFields"]
+[node name="ItemAcquiredMetadata" type="LineEdit" parent="Margin/Scroll/VBox/ItemAcquiredSection/ItemAcquiredFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "{\"rarity\": \"rare\"}"
 
-[node name="ItemAcquiredEmitButton" type="Button" parent="Margin/VBox/ItemAcquiredSection"]
+[node name="ItemAcquiredEmitButton" type="Button" parent="Margin/Scroll/VBox/ItemAcquiredSection"]
 unique_name_in_owner = true
 text = "Emit item_acquired"
 
-[node name="Separator3" type="HSeparator" parent="Margin/VBox"]
+[node name="Separator3" type="HSeparator" parent="Margin/Scroll/VBox"]
 
-[node name="QuestStateChangedSection" type="VBoxContainer" parent="Margin/VBox"]
+[node name="QuestStateChangedSection" type="VBoxContainer" parent="Margin/Scroll/VBox"]
 
-[node name="QuestStateChangedLabel" type="Label" parent="Margin/VBox/QuestStateChangedSection"]
+[node name="QuestStateChangedLabel" type="Label" parent="Margin/Scroll/VBox/QuestStateChangedSection"]
 text = "quest_state_changed"
 
-[node name="QuestStateChangedFields" type="GridContainer" parent="Margin/VBox/QuestStateChangedSection"]
+[node name="QuestStateChangedFields" type="GridContainer" parent="Margin/Scroll/VBox/QuestStateChangedSection"]
 columns = 2
 
-[node name="QuestStateChangedQuestIdLabel" type="Label" parent="Margin/VBox/QuestStateChangedSection/QuestStateChangedFields"]
+[node name="QuestStateChangedQuestIdLabel" type="Label" parent="Margin/Scroll/VBox/QuestStateChangedSection/QuestStateChangedFields"]
 text = "quest_id"
 
-[node name="QuestStateChangedQuestId" type="LineEdit" parent="Margin/VBox/QuestStateChangedSection/QuestStateChangedFields"]
+[node name="QuestStateChangedQuestId" type="LineEdit" parent="Margin/Scroll/VBox/QuestStateChangedSection/QuestStateChangedFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "quest_id"
 
-[node name="QuestStateChangedStateLabel" type="Label" parent="Margin/VBox/QuestStateChangedSection/QuestStateChangedFields"]
+[node name="QuestStateChangedStateLabel" type="Label" parent="Margin/Scroll/VBox/QuestStateChangedSection/QuestStateChangedFields"]
 text = "state"
 
-[node name="QuestStateChangedState" type="LineEdit" parent="Margin/VBox/QuestStateChangedSection/QuestStateChangedFields"]
+[node name="QuestStateChangedState" type="LineEdit" parent="Margin/Scroll/VBox/QuestStateChangedSection/QuestStateChangedFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "state"
 
-[node name="QuestStateChangedProgressLabel" type="Label" parent="Margin/VBox/QuestStateChangedSection/QuestStateChangedFields"]
+[node name="QuestStateChangedProgressLabel" type="Label" parent="Margin/Scroll/VBox/QuestStateChangedSection/QuestStateChangedFields"]
 text = "progress (optional)"
 
-[node name="QuestStateChangedProgress" type="LineEdit" parent="Margin/VBox/QuestStateChangedSection/QuestStateChangedFields"]
+[node name="QuestStateChangedProgress" type="LineEdit" parent="Margin/Scroll/VBox/QuestStateChangedSection/QuestStateChangedFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "e.g. 0.5"
 
-[node name="QuestStateChangedObjectivesLabel" type="Label" parent="Margin/VBox/QuestStateChangedSection/QuestStateChangedFields"]
+[node name="QuestStateChangedObjectivesLabel" type="Label" parent="Margin/Scroll/VBox/QuestStateChangedSection/QuestStateChangedFields"]
 text = "objectives (optional)"
 
-[node name="QuestStateChangedObjectives" type="LineEdit" parent="Margin/VBox/QuestStateChangedSection/QuestStateChangedFields"]
+[node name="QuestStateChangedObjectives" type="LineEdit" parent="Margin/Scroll/VBox/QuestStateChangedSection/QuestStateChangedFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "[{\"id\": \"slay\"}]"
 
-[node name="QuestStateChangedMetadataLabel" type="Label" parent="Margin/VBox/QuestStateChangedSection/QuestStateChangedFields"]
+[node name="QuestStateChangedMetadataLabel" type="Label" parent="Margin/Scroll/VBox/QuestStateChangedSection/QuestStateChangedFields"]
 text = "metadata (optional)"
 
-[node name="QuestStateChangedMetadata" type="LineEdit" parent="Margin/VBox/QuestStateChangedSection/QuestStateChangedFields"]
+[node name="QuestStateChangedMetadata" type="LineEdit" parent="Margin/Scroll/VBox/QuestStateChangedSection/QuestStateChangedFields"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "{\"xp\": 120}"
 
-[node name="QuestStateChangedEmitButton" type="Button" parent="Margin/VBox/QuestStateChangedSection"]
+[node name="QuestStateChangedEmitButton" type="Button" parent="Margin/Scroll/VBox/QuestStateChangedSection"]
 unique_name_in_owner = true
 text = "Emit quest_state_changed"
 
-[node name="Separator4" type="HSeparator" parent="Margin/VBox"]
+[node name="Separator4" type="HSeparator" parent="Margin/Scroll/VBox"]
 
-[node name="LogLabel" type="Label" parent="Margin/VBox"]
+[node name="LogLabel" type="Label" parent="Margin/Scroll/VBox"]
 text = "Signal Log"
 
-[node name="Log" type="RichTextLabel" parent="Margin/VBox"]
+[node name="Log" type="RichTextLabel" parent="Margin/Scroll/VBox"]
 unique_name_in_owner = true
 size_flags_horizontal = 3
 size_flags_vertical = 3


### PR DESCRIPTION
## Summary
- wrap the EventBus test harness content in a ScrollContainer so the full interface remains accessible

## Testing
- `godot4 --headless --path . --run tests_manifest.json` *(fails: command not found: godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68c87850fc0c8320bc18c9fc730d8e13