### PR TITLE
Configure autoload singletons for global registries

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -13,3 +13,7 @@ config_version=5
 config/name="G-LEV-3.0DEV"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
+[autoload]
+EventBus="*res://src/globals/EventBus.gd"
+AssetRegistry="*res://src/globals/AssetRegistry.gd"
+ModuleRegistry="*res://src/globals/ModuleRegistry.gd"


### PR DESCRIPTION
## Summary
- register the EventBus, AssetRegistry, and ModuleRegistry singletons as autoloads in the Godot project settings

## Testing
- godot --headless --run *(fails: command not found)*
- godot4 --headless --run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c87e14114c8320a5dcd4c0b198fced