### PR TITLE
Add developer docs for registries

### DIFF
--- a/devdocs/AssetRegistry.md
+++ b/devdocs/AssetRegistry.md
@@ -1,0 +1,37 @@
+# AssetRegistry
+
+The `AssetRegistry` is a lightweight loader responsible for discovering `.tres` resources at startup and exposing them through a uniform lookup API. It is designed for Godot 4.4.1 and lives at `res://src/globals/AssetRegistry.gd`.
+
+## Initialization Sequence
+1. **Autoload setup (recommended):** Add `AssetRegistry.gd` as an Autoload singleton (Project Settings → Autoload) so it enters the scene tree during engine boot. Because the script extends `Node`, the `_ready()` callback executes automatically and primes the registry.
+2. **Default preload path:** During `_ready()` the registry calls `_scan_and_load_assets("res://assets/items/")`, traversing the directory for `.tres` files and storing each successfully loaded `Resource` in its internal dictionary. This ensures common gameplay assets are immediately available.
+3. **Manual instancing (for tests or tools):** You can instantiate the registry manually when running in isolation (for example, unit tests) and call `_scan_and_load_assets()` for the directories you need. The test suite demonstrates this approach to avoid relying on project autoloads.
+
+## Registration Methods
+- **Directory scans:** `_scan_and_load_assets(path: String)` opens the provided directory, iterates over its contents, and loads any file ending in `.tres`. Successfully loaded resources are stored in the `assets` dictionary keyed by file name (e.g., `"flame_sword.tres"`). Loading failures trigger `push_error` messages so issues surface in the editor or console.
+- **Custom additions:** For ad-hoc registrations (such as procedurally generated resources), you can assign directly into `assets[name] = resource` after ensuring the value is a valid `Resource`. Maintain unique keys to avoid overwriting previously loaded assets.
+
+## Retrieval Patterns
+- `get_asset(name: String) -> Resource` returns the resource associated with the requested file name, or `null` when nothing was registered under that key. Callers should null-check the return value before use.
+- When querying from gameplay code, prefer using constants or enumerations for the keys to reduce typographical errors.
+
+## Common Use Cases
+```gdscript
+# Example: retrieving a preloaded asset from the singleton registry.
+var sword_data := AssetRegistry.get_asset("heroic_sword.tres")
+if sword_data:
+    inventory.add_item(sword_data)
+else:
+    push_warning("Missing asset: heroic_sword.tres")
+```
+
+```gdscript
+# Example: manually extending the registry during a tool pipeline.
+var local_registry := AssetRegistry.new()
+local_registry._scan_and_load_assets("res://addons/custom_items/")
+var prototype := local_registry.get_asset("prototype_item.tres")
+```
+
+## Maintenance Tips
+- Keep asset directories flat or ensure `_scan_and_load_assets` is invoked recursively if subdirectories become necessary.
+- Clear or rebuild the registry (`assets.clear()`) when hot-reloading resource packs to avoid stale references.

--- a/devdocs/ModuleRegistry.md
+++ b/devdocs/ModuleRegistry.md
@@ -1,0 +1,36 @@
+# ModuleRegistry
+
+`ModuleRegistry` provides a centralized place to register and retrieve gameplay modules at runtime. Modules are stored by name, enabling systems to look up collaborators without hard-wiring scene tree paths. The script lives at `res://src/globals/ModuleRegistry.gd` and targets Godot 4.4.1.
+
+## Initialization Sequence
+1. **Autoload setup (recommended):** Add `ModuleRegistry.gd` as an Autoload singleton so it is available globally. Because it extends `Node`, no additional configuration is required beyond the autoload entry.
+2. **Manual instancing for isolated contexts:** Tests or editor tools can instantiate the registry directly by calling `ModuleRegistry.new()`. The existing test suite follows this pattern so that each scenario starts with a clean registry state.
+3. **Lifecycle management:** When the registry is about to be discarded (for example, in tests), clear any stored modules and free the instance to avoid leaking references.
+
+## Registration Methods
+- `register_module(name: String, node: Node)` stores the supplied node under the provided name. Re-registering an existing name overwrites the previous value, which is helpful for replacing modules during hot-reload workflows.
+- You can register any node type, including systems, services, or UI managers. Keep module names consistent by defining them as constants (for example, in an `Enums.gd` file) to avoid typos.
+
+### Example: registering from a module's `_ready`
+```gdscript
+func _ready() -> void:
+    ModuleRegistry.register_module("loot_generator", self)
+```
+
+## Retrieval Patterns
+- `get_module(name: String) -> Node` returns the stored module node or `null` if the name has not been registered. Always guard against a `null` return to fail gracefully.
+- `has_module(name: String) -> bool` reports whether a module exists under the key. Use this before calling `get_module` when you need to branch logic.
+
+### Example: consuming a registered module
+```gdscript
+var loot_gen := ModuleRegistry.get_module("loot_generator")
+if loot_gen:
+    var drop := loot_gen.roll_loot_for(enemy_data)
+else:
+    push_warning("Loot generator module not registered; falling back to defaults.")
+```
+
+## Common Workflows
+- **Hot swapping modules:** Call `register_module` again with a replacement node. The latest registration always wins, as validated by the test coverage.
+- **Optional dependencies:** Use `has_module` to detect whether optional subsystems (such as analytics or debugging tools) are active before invoking them.
+- **Tear-down:** Explicitly unregister modules (`modules.erase(name)`) or call `modules.clear()` when unloading a game mode to avoid stale references in subsequent runs.


### PR DESCRIPTION
## Summary
- add a dedicated developer guide for the AssetRegistry covering initialization, scanning, and usage patterns
- document the ModuleRegistry lifecycle, registration API, and common consumption patterns

## Testing
- `godot --headless --path . --test` *(fails: `godot` binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c87e17a2748320809963d95daf0603