### PR TITLE
Fix EventBusHarness field name normalization

### DIFF
--- a/src/tests/EventBusHarness.gd
+++ b/src/tests/EventBusHarness.gd
@@ -119,7 +119,9 @@ func _populate_field_rows(
     for raw_key in definitions.keys():
         normalized[String(raw_key)] = definitions[raw_key]
 
-    var field_names: Array[String] = normalized.keys()
+    var field_names: Array[String] = []
+    for raw_field_name in normalized.keys():
+        field_names.append(String(raw_field_name))
     field_names.sort()
 
     for field_name in field_names:


### PR DESCRIPTION
## Summary
- ensure the EventBusHarness converts normalized field keys into a typed string array before sorting

## Testing
- godot --headless --path . --run-tests --test json --output tests/results.json *(fails: `godot` CLI not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a9df1730832092b13e0acaaf6f23