### PR TITLE
Fix EventBus harness log visibility

### DIFF
--- a/tests/EventBus_TestHarness.tscn
+++ b/tests/EventBus_TestHarness.tscn
@@ -70,6 +70,7 @@ text = "Replay Log"
 
 [node name="Log" type="RichTextLabel" parent="Margin/Scroll/VBox"]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 320)
 size_flags_horizontal = 3
 size_flags_vertical = 3
 scroll_active = true


### PR DESCRIPTION
## Summary
- ensure the EventBus harness log panel has a minimum height so the scroll container reaches it in the editor

## Testing
- not run (Godot CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8adcc66948320b4149d86659b5650