### PR TITLE
Implement asset and module registries

### DIFF
--- a/devdocs/Designers/AssetRegistry.md
+++ b/devdocs/Designers/AssetRegistry.md
@@ -4,15 +4,16 @@ The `AssetRegistry` is a lightweight loader responsible for discovering `.tres` 
 
 ## Initialization Sequence
 1. **Autoload setup (recommended):** Add `AssetRegistry.gd` as an Autoload singleton (Project Settings → Autoload) so it enters the scene tree during engine boot. Because the script extends `Node`, the `_ready()` callback executes automatically and primes the registry.
-2. **Default preload path:** During `_ready()` the registry calls `_scan_and_load_assets("res://assets/items/")`, traversing the directory for `.tres` files and storing each successfully loaded `Resource` in its internal dictionary. This ensures common gameplay assets are immediately available.
-3. **Manual instancing (for tests or tools):** You can instantiate the registry manually when running in isolation (for example, unit tests) and call `_scan_and_load_assets()` for the directories you need. The test suite demonstrates this approach to avoid relying on project autoloads.
+2. **Default preload path:** During `_ready()` the registry iterates over the exported `directories_to_scan` array (which defaults to `res://assets/`) and recursively ingests every `.tres` file it finds. Each successfully loaded `Resource` is cached in the internal dictionary so systems can fetch handcrafted data without performing additional disk I/O.
+3. **Manual instancing (for tests or tools):** You can instantiate the registry manually when running in isolation (for example, unit tests) and call `_scan_and_load_assets()` for any directory tree you need. The helper preserves the recursive scan behaviour used at runtime, making it ideal for verifying new asset packs before promoting them into the main project.
 
 ## Registration Methods
-- **Directory scans:** `_scan_and_load_assets(path: String)` opens the provided directory, iterates over its contents, and loads any file ending in `.tres`. Successfully loaded resources are stored in the `assets` dictionary keyed by file name (e.g., `"flame_sword.tres"`). Loading failures trigger `push_error` messages so issues surface in the editor or console.
+- **Directory scans:** `_scan_and_load_assets(path: String)` opens the provided directory, iterates over its contents, and loads any file ending in `.tres`. The method walks subdirectories automatically, so providing a root such as `res://assets/` discovers the entire handcrafted catalogue. Successfully loaded resources are stored in the `assets` dictionary keyed by file name (e.g., `"flame_sword.tres"`). Loading failures trigger `push_error` messages so issues surface in the editor or console while continuing the scan.
 - **Custom additions:** For ad-hoc registrations (such as procedurally generated resources), you can assign directly into `assets[name] = resource` after ensuring the value is a valid `Resource`. Maintain unique keys to avoid overwriting previously loaded assets.
 
 ## Retrieval Patterns
 - `get_asset(name: String) -> Resource` returns the resource associated with the requested file name, or `null` when nothing was registered under that key. Callers should null-check the return value before use.
+- `has_asset(name: String) -> bool` offers a cheap existence check when you need to branch logic without paying the cost of retrieving the underlying resource.
 - When querying from gameplay code, prefer using constants or enumerations for the keys to reduce typographical errors.
 
 ## Common Use Cases
@@ -33,5 +34,5 @@ var prototype := local_registry.get_asset("prototype_item.tres")
 ```
 
 ## Maintenance Tips
-- Keep asset directories flat or ensure `_scan_and_load_assets` is invoked recursively if subdirectories become necessary.
+- Keep asset directories organised by theme or feature; the recursive scan handles nested directories automatically.
 - Clear or rebuild the registry (`assets.clear()`) when hot-reloading resource packs to avoid stale references.

--- a/src/globals/AssetRegistry.gd
+++ b/src/globals/AssetRegistry.gd
@@ -1,34 +1,76 @@
 extends Node
 class_name AssetRegistrySingleton
 
-## Registry responsible for loading and providing game assets.
+## Registry responsible for discovering handcrafted `.tres` assets and providing
+## fast, in-memory lookup access for the rest of the project.
 ## Designed for Godot 4.4.1.
+
+## Default directories scanned during `_ready()`. The list mirrors the paths
+## referenced throughout the design bible and can be customized through the
+## exported `directories_to_scan` property.
+const DEFAULT_SCAN_DIRECTORIES: Array[String] = [
+    "res://assets/",
+]
+
+## File extension the registry indexes. Keeping this in a constant makes future
+## expansion (e.g., `.res`, `.tres` hybrids) trivial.
+const RESOURCE_EXTENSION := ".tres"
 
 ## Maps asset identifiers (file names) to the loaded `Resource` objects.
 ## Using a typed dictionary makes intent explicit for engineers integrating new loaders.
 var assets: Dictionary[String, Resource] = {}
 
-func _ready() -> void:
-    # Preload default item assets on startup.
-    _scan_and_load_assets("res://assets/items/")
+## Directories recursively scanned for resources when the singleton becomes ready.
+@export var directories_to_scan: Array[String] = DEFAULT_SCAN_DIRECTORIES.duplicate()
 
-## Scans a directory for .tres resources and loads them into the registry.
+func _ready() -> void:
+    ## Reset the cache in case the singleton is reloaded during hot-swap testing.
+    assets.clear()
+
+    for directory_path in directories_to_scan:
+        _scan_and_load_assets(directory_path)
+
+## Scans a directory tree for `.tres` resources and loads them into the registry.
+## This helper is intentionally public so tests can target arbitrary mock directories
+## without mutating the autoload's startup configuration.
 func _scan_and_load_assets(path: String) -> void:
-    var dir := DirAccess.open(path)
-    if dir:
-        dir.list_dir_begin()
-        var file_name := dir.get_next()
-        while file_name != "":
-            if file_name.ends_with(".tres"):
-                var res := load(path + file_name)
-                if res:
-                    assets[file_name] = res
-                else:
-                    push_error("Failed to load: " + file_name)
-            file_name = dir.get_next()
-        dir.list_dir_end()
-    else:
-        push_error("Failed to open directory: %s" % path)
+    var normalized_path := _ensure_directory_suffix(path)
+    var dir := DirAccess.open(normalized_path)
+    if dir == null:
+        push_warning("AssetRegistry: Unable to open directory '%s'." % normalized_path)
+        return
+
+    dir.list_dir_begin(true, true)
+    var file_name := dir.get_next()
+    while file_name != "":
+        var entry_path := normalized_path + file_name
+        if dir.current_is_dir():
+            _scan_and_load_assets(entry_path)
+        elif file_name.ends_with(RESOURCE_EXTENSION):
+            _ingest_resource(entry_path, file_name)
+
+        file_name = dir.get_next()
+    dir.list_dir_end()
+
+## Normalizes a directory path so concatenation keeps a single trailing slash.
+func _ensure_directory_suffix(path: String) -> String:
+    if path == "":
+        return path
+    if not path.ends_with("/"):
+        return path + "/"
+    return path
+
+## Loads a resource and records it under the provided key if successful.
+func _ingest_resource(resource_path: String, asset_key: String) -> void:
+    var resource := ResourceLoader.load(resource_path)
+    if resource == null:
+        push_error("AssetRegistry: Failed to load resource at '%s'." % resource_path)
+        return
+
+    if assets.has(asset_key):
+        push_warning("AssetRegistry: Duplicate asset key '%s' encountered. Replacing existing entry." % asset_key)
+
+    assets[asset_key] = resource
 
 ## Retrieves a previously loaded asset by file name.
 ##
@@ -36,3 +78,7 @@ func _scan_and_load_assets(path: String) -> void:
 ## @return The registered resource, or `null` when the asset has not been scanned yet.
 func get_asset(asset_name: String) -> Resource:
     return assets.get(asset_name, null)
+
+## Checks whether an asset key exists inside the registry cache.
+func has_asset(asset_name: String) -> bool:
+    return assets.has(asset_name)

--- a/src/globals/ModuleRegistry.gd
+++ b/src/globals/ModuleRegistry.gd
@@ -12,14 +12,27 @@ var modules: Dictionary[StringName, Node] = {}
 ## @param module_name Identifier used for lookups (prefer a `StringName` constant shared across systems).
 ## @param node Concrete module instance to expose through the registry.
 func register_module(module_name: StringName, node: Node) -> void:
-    modules[module_name] = node
+    if node == null:
+        push_warning("ModuleRegistry: Attempted to register a null module for '%s'." % module_name)
+        return
+
+    var key := StringName(module_name)
+    if modules.has(key):
+        push_warning("ModuleRegistry: Replacing existing module registration for '%s'." % key)
+
+    modules[key] = node
+
+## Removes a module from the registry.
+## Systems can call this when a generator exits the scene tree or is about to free itself.
+func unregister_module(module_name: StringName) -> void:
+    modules.erase(StringName(module_name))
 
 ## Retrieves a previously registered module.
 ## Returns `null` when no module exists for the provided name.
 ## The return type is intentionally `Node` to remain agnostic about the module's concrete implementation.
 func get_module(module_name: StringName) -> Node:
-    return modules.get(module_name, null)
+    return modules.get(StringName(module_name), null)
 
 ## Checks if a module has been registered under the provided name.
 func has_module(module_name: StringName) -> bool:
-    return modules.has(module_name)
+    return modules.has(StringName(module_name))


### PR DESCRIPTION
## Summary
- expand the AssetRegistry singleton to recursively preload .tres resources, expose configuration hooks, and add defensive logging
- harden the ModuleRegistry singleton with duplicate/null guards and an unregister helper for generator lifecycles
- refresh the designer documentation to describe the new scan behaviour and lookup helpers

## Testing
- not run (godot4 CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8b2bcf8c88320a659a3511682636a