### PR TITLE
Fix DirAccess list_dir_begin usage for Godot 4.4

### DIFF
--- a/src/globals/AssetRegistry.gd
+++ b/src/globals/AssetRegistry.gd
@@ -46,7 +46,12 @@ func _scan_and_load_assets(path: String) -> void:
         push_warning("AssetRegistry: Unable to open directory '%s'." % normalized_path)
         return
 
-    dir.list_dir_begin(true, true)
+    ## Godot 4.4 made `list_dir_begin()` parameterless and instead relies on
+    ## the `include_hidden` and `include_navigational` flags, so mirror the
+    ## previous skip behaviour explicitly before starting the iteration.
+    dir.include_navigational = false
+    dir.include_hidden = false
+    dir.list_dir_begin()
     var file_name := dir.get_next()
     while file_name != "":
         var entry_path := normalized_path + file_name


### PR DESCRIPTION
## Summary
- update the AssetRegistry directory scan to use the Godot 4.4 DirAccess flags instead of deprecated list_dir_begin parameters
- document why the include_hidden and include_navigational flags are set to preserve the previous skip behavior

## Testing
- not run (godot4 binary is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8c140a0d48320b5bfbeddb42646ed