### PR TITLE
Improve archetype trait validation logic

### DIFF
--- a/src/systems/Archetype.gd
+++ b/src/systems/Archetype.gd
@@ -14,29 +14,87 @@ class_name Archetype
 @export var required_traits: Array[Trait] = []
 @export var trait_pool: Array[Trait] = []
 
-## Returns all traits that the archetype explicitly allows.
+## Returns all traits that the archetype explicitly allows. Required traits are
+## always positioned ahead of optional entries while duplicates (matched by
+## ``trait_id``) are removed to keep the payload stable for downstream systems.
 func get_all_traits() -> Array[Trait]:
     var combined: Array[Trait] = []
-    combined.append_array(required_traits)
-    for trait in trait_pool:
-        if trait not in combined:
-            combined.append(trait)
+    var seen_ids: Dictionary = {}
+    _append_unique_traits(combined, required_traits, seen_ids)
+    _append_unique_traits(combined, trait_pool, seen_ids)
     return combined
 
 ## Determines if a specific trait resource is compatible with the archetype.
+## Invalid inputs (``null`` or missing identifiers) are rejected before
+## searching the combined list to avoid nil dereferences in consuming systems.
 func is_trait_allowed(trait: Trait) -> bool:
-    if trait == null:
+    if not _is_trait_resource_valid(trait):
         return false
-    return trait in get_all_traits()
+    var allowed_traits: Array[Trait] = get_all_traits()
+    var index := 0
+    while index < allowed_traits.size():
+        if allowed_traits[index].trait_id == trait.trait_id:
+            return true
+        index += 1
+    return false
 
-## Validates that a trait component satisfies the archetype rules.
+## Validates that a trait component satisfies the archetype rules. The
+## component must expose all required trait identifiers and may not advertise
+## traits outside of the archetype's combined pool. Any null or malformed
+## entries are rejected to maintain the integrity of entity data resources.
 func validate_component(component: TraitComponent) -> bool:
     if component == null:
         return false
-    for trait in required_traits:
-        if not component.has_trait_id(trait.trait_id):
+
+    var allowed_traits: Array[Trait] = get_all_traits()
+    var allowed_trait_ids: Dictionary = _collect_trait_id_lookup(allowed_traits)
+
+    var index := 0
+    while index < required_traits.size():
+        var required_trait: Trait = required_traits[index]
+        if _is_trait_resource_valid(required_trait):
+            if not component.has_trait_id(required_trait.trait_id):
+                return false
+        else:
             return false
-    for trait in component.traits:
-        if not is_trait_allowed(trait):
+        index += 1
+
+    index = 0
+    while index < component.traits.size():
+        var trait: Trait = component.traits[index]
+        if not _is_trait_resource_valid(trait):
             return false
+        if not allowed_trait_ids.has(trait.trait_id):
+            return false
+        index += 1
+
     return true
+
+## Helper that copies valid, non-duplicate traits from ``source`` into
+## ``target`` while preserving order. ``seen_ids`` tracks identifiers already
+## appended to the target array so optional traits do not overwrite required
+## selections.
+func _append_unique_traits(target: Array[Trait], source: Array[Trait], seen_ids: Dictionary) -> void:
+    var index := 0
+    while index < source.size():
+        var trait: Trait = source[index]
+        if _is_trait_resource_valid(trait):
+            var trait_id := trait.trait_id
+            if not seen_ids.has(trait_id):
+                target.append(trait)
+                seen_ids[trait_id] = true
+        index += 1
+
+## Builds a dictionary keyed by ``trait_id`` for fast membership checks against
+## the archetype's combined trait list.
+func _collect_trait_id_lookup(traits: Array[Trait]) -> Dictionary:
+    var lookup: Dictionary = {}
+    var index := 0
+    while index < traits.size():
+        lookup[traits[index].trait_id] = true
+        index += 1
+    return lookup
+
+## Returns ``true`` when the provided resource is a valid trait definition.
+func _is_trait_resource_valid(trait: Trait) -> bool:
+    return trait != null and trait.trait_id != ""


### PR DESCRIPTION
## Summary
- deduplicate archetype trait lists while preserving the required-versus-optional ordering
- harden trait validation by rejecting null or malformed resources and precomputing identifier lookups for membership checks
- document helper routines so external engineers understand the data validation pipeline around archetype resources

## Testing
- not run (godot4 CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8c6de38ec8320b64fb9f513ec3061