### PR TITLE
Fix DebugSystem entity_id typing

### DIFF
--- a/src/systems/DebugSystem.gd
+++ b/src/systems/DebugSystem.gd
@@ -114,5 +114,6 @@ func _on_entity_killed(payload: Dictionary) -> void:
     if not payload.has("entity_id"):
         return
 
-    var entity_id := payload["entity_id"]
+    # Coerce the identifier to a String so downstream tooling receives a stable type.
+    var entity_id: String = str(payload["entity_id"])
     print("DebugSystem observed entity_killed for %s" % str(entity_id))


### PR DESCRIPTION
## Summary
- ensure DebugSystem casts the EventBus payload identifier to a String before logging so the parser can infer the variable type and downstream tools receive a stable value

## Testing
- godot4 --headless --path . --run-tests *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d0ade0b08320a2fe2929b99c5ac1