### PR TITLE
Add shared enums singleton and debugger plan

### DIFF
--- a/devdocs/autoload_debugger_plan.md
+++ b/devdocs/autoload_debugger_plan.md
@@ -1,0 +1,92 @@
+# Autoload Debugger Implementation Plan
+
+## Purpose and Guiding Principles
+- Provide a unified, always-on diagnostics layer for all autoload singletons (`EventBus`, `AssetRegistry`, `ModuleRegistry`, and `Enums`).
+- Record high-signal error and warning events with enough structured metadata that engineers can triage issues without reproducing them locally.
+- Preserve the low-friction workflow established in the design docs: singletons remain lightweight and decoupled, while the debugger observes their behaviour without introducing circular dependencies.
+- Ship editor-friendly tooling (a dockable panel and exported reports) so designers can view validation output when authoring resources.
+
+## Autoload Inventory and Instrumentation Points
+
+### EventBus (`res://src/globals/EventBus.gd`)
+- Already validates payloads inside `emit_signal()` and produces `push_error` messages when contracts are violated.
+- Provides structured signal metadata through `SIGNAL_CONTRACTS` and `describe_signal()`.
+- **Hook Plan:** Wrap `emit_signal()` to forward validation results (success or error code) and payload snapshots to the debugger. Capture:
+  - Signal name, payload dictionary, contract lookup, validation result.
+  - Caller stack snippet (via `get_stack()` when running in debug builds).
+  - Timestamp to reconstruct chronological order during multi-system tests.
+
+### AssetRegistry (`res://src/globals/AssetRegistry.gd`)
+- Performs recursive directory scans and records failures in `failed_assets` while emitting `push_warning` / `push_error` logs.
+- **Hook Plan:** Emit structured events whenever:
+  - A directory cannot be opened (`_scan_and_load_assets`).
+  - A resource fails to load (`_ingest_resource`).
+  - A duplicate key replaces an existing asset.
+- Recorded metadata: path, error code, Godot error string, optional stack trace, registry snapshot counts (assets vs. failures).
+
+### ModuleRegistry (`res://src/globals/ModuleRegistry.gd`)
+- Manages lifecycle of procedural modules with guard rails (`push_warning` on invalid registrations, cleanup hooks, etc.).
+- **Hook Plan:** Report key transitions to the debugger:
+  - Registration, replacement, and unregistration events.
+  - Automatic clean-up triggered by `_on_module_tree_exiting`.
+  - Any rejected registration attempts (empty name, invalid node).
+- Metadata to include: module name (`StringName`), node path, validity flags, and whether the event was manual or automatic.
+
+### Enums (`res://src/globals/Enums.gd`)
+- Defines entity taxonomy and `ComponentKeys` metadata plus validation helpers (`assert_valid_*`, `inspect_component_dictionary`, etc.).
+- **Hook Plan:**
+  - Instrument `assert_valid_entity_type` and `assert_valid_component_key` so both log to the debugger in addition to `push_error` when a check fails.
+  - When `inspect_component_dictionary()` or `validate_component_dictionary()` run, forward the generated report/messages to the debugger for archival.
+- Captured metadata: offending value, normalized key, validation report, context dictionary provided by caller when available.
+
+## Autoload Debugger Design Overview
+
+### Singleton Responsibilities
+1. **Event Bus for Diagnostics:** Provide typed methods such as `log_error(source: StringName, payload: Dictionary)` and `log_warning(...)` so monitored singletons forward structured data without depending on concrete debugger implementation.
+2. **Persistent Ring Buffer:** Maintain bounded history (configurable size) storing dictionaries with fields:
+   - `timestamp` (float, `Time.get_singleton().get_ticks_msec()/1000.0`).
+   - `source_autoload` (`StringName`).
+   - `event` (`StringName`, e.g., `signal_validation_failed`, `asset_load_failed`).
+   - `severity` (enum with values INFO/WARNING/ERROR).
+   - `details` (Dictionary mirroring singleton-specific metadata defined above).
+3. **Export Interfaces:**
+   - Method returning a deep copy of the log for tests (`export_log(): Array[Dictionary]`).
+   - Optional streaming signal `debug_event_logged(details: Dictionary)` so UI panels can update live.
+4. **Aggregation Helpers:** Provide query helpers (e.g., `find_latest_errors(source_autoload: StringName)`), JSON export for CI attachments, and summary stats for quick health overviews.
+
+### Integration Strategy
+- The debugger lives in `res://src/globals/AutoloadDebugger.gd` and is autoloaded before other singletons so hooks are available during their `_ready()` callbacks.
+- Each monitored singleton imports the debugger via `const AutoloadDebugger = preload("res://src/globals/AutoloadDebugger.gd")` or by calling `AutoloadDebugger.get_singleton()` if we mirror the pattern used by `EventBus`.
+- Introduce minimal wrapper helpers (e.g., `_report_error(event: StringName, details: Dictionary)`) inside each singleton to avoid repetitive boilerplate and to ensure logging survives refactors.
+- Maintain optional toggles (exported booleans) so developers can disable verbose logging in performance-critical builds.
+
+## Data Model Specification
+| Field             | Type          | Description                                                                 |
+|-------------------|---------------|-----------------------------------------------------------------------------|
+| `timestamp`       | `float`       | UTC timestamp in seconds when the event was recorded.                       |
+| `source_autoload` | `StringName`  | Which singleton reported the event.                                         |
+| `event`           | `StringName`  | Event identifier (`signal_emitted`, `component_key_invalid`, etc.).         |
+| `severity`        | `int` enum    | 0 = INFO, 1 = WARNING, 2 = ERROR.                                           |
+| `details`         | `Dictionary`  | Source-specific payload (payload copies, module names, validation issues).  |
+| `stack` *(opt)*   | `Array`       | Optional call stack frames when captured (debug builds only).              |
+
+## Phase Breakdown
+1. **Foundation (Sprint 1):**
+   - Implement `AutoloadDebugger` with ring buffer, export functions, and optional signal.
+   - Add autoload entry and confirm singleton order (Debugger first).
+   - Unit test core logging API using minimal Godot headless scripts or GUT harness.
+2. **Instrumentation (Sprint 2):**
+   - Update each singleton to import the debugger and emit structured events at the touch points described above.
+   - Extend existing tests (e.g., EventBus test harness) to assert the debugger captured validation failures correctly.
+3. **Editor Tooling (Sprint 3):**
+   - Build a `Control`-based dock that subscribes to `debug_event_logged` and visualises records (filter by source, severity, time range).
+   - Provide export button writing JSON to `res://tests/results/` for inclusion in CI artifacts.
+4. **Advanced Analytics (Stretch):**
+   - Correlate repeated errors (e.g., same asset failing to load multiple times) and surface aggregated counts.
+   - Integrate with `Enums.inspect_component_dictionary()` to annotate entries with missing component keys vs. null references.
+
+## Testing and Maintenance Plan
+- Extend automated regression scenes (`EventBus_TestHarness.tscn`, `Sprint1_Validation.tscn`) with scripts that intentionally trigger errors and then assert the debugger recorded them.
+- Provide a CLI script (GDScript `@tool`) to dump the debugger log for QA triage.
+- Document onboarding steps in `devdocs` so new engineers know how to enable verbose logging and interpret debugger output.
+- Schedule quarterly audits of the debugger schema to accommodate new autoloads or metadata requirements.

--- a/project.godot
+++ b/project.godot
@@ -14,6 +14,7 @@ config/name="G-LEV-3.0DEV"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
 [autoload]
+Enums="*res://src/globals/Enums.gd"
 EventBus="*res://src/globals/EventBus.gd"
 AssetRegistry="*res://src/globals/AssetRegistry.gd"
 ModuleRegistry="*res://src/globals/ModuleRegistry.gd"

--- a/src/globals/Enums.gd
+++ b/src/globals/Enums.gd
@@ -1,0 +1,210 @@
+extends Node
+class_name Enums
+
+## Central catalogue of enumerations and string keys shared across gameplay systems.
+##
+## Godot autoloads this script as `Enums` so engineers and designers can reference
+## typo-safe constants such as `Enums.EntityType.MONSTER` or
+## `Enums.ComponentKeys.STATS`. Centralizing the identifiers ensures that
+## dictionaries used by `EntityData` remain consistent across procedural tools,
+## authored resources, and runtime systems. The helper methods in this singleton
+## expose diagnostic utilities for validating data payloads whenever the project
+## surfaces mysterious dictionary state.
+
+enum EntityType {
+    PLAYER,
+    NPC,
+    MONSTER,
+    WILDLIFE,
+    OBJECT,
+}
+
+## Maps entity type IDs back to their symbolic labels so debug panels and log
+## statements can present human-readable information.
+const _ENTITY_TYPE_NAMES := {
+    EntityType.PLAYER: &"PLAYER",
+    EntityType.NPC: &"NPC",
+    EntityType.MONSTER: &"MONSTER",
+    EntityType.WILDLIFE: &"WILDLIFE",
+    EntityType.OBJECT: &"OBJECT",
+}
+
+## Namespace of canonical dictionary keys used throughout EntityData.
+## All keys are declared as `StringName` values so runtime lookups remain fast
+## while still saving as readable strings inside `.tres` resources.
+class ComponentKeys:
+    const STATS := &"stats"
+    const TRAITS := &"traits"
+    const STATUS := &"status"
+    const SKILLS := &"skills"
+    const INVENTORY := &"inventory"
+    const AI_BEHAVIOR := &"ai_behavior"
+    const FACTION := &"faction"
+    const QUEST_STATE := &"quest_state"
+
+    ## Returns a PackedStringArray containing every registered key. Useful for
+    ## building editor drop-downs or for quick iteration in validation scripts.
+    static func all() -> PackedStringArray:
+        var keys := PackedStringArray()
+        keys.append_array([
+            String(STATS),
+            String(TRAITS),
+            String(STATUS),
+            String(SKILLS),
+            String(INVENTORY),
+            String(AI_BEHAVIOR),
+            String(FACTION),
+            String(QUEST_STATE),
+        ])
+        return keys
+
+## Descriptive metadata for each component key so debug tooling can surface the
+## expected resource types and high-level intent to engineers.
+const COMPONENT_KEY_METADATA := {
+    ComponentKeys.STATS: {
+        "description": "Primary combat and utility statistics supplied by StatsComponent resources.",
+        "resource": &"StatsComponent",
+    },
+    ComponentKeys.TRAITS: {
+        "description": "Collection of TraitComponent resources defining passive modifiers and narrative hooks.",
+        "resource": &"TraitComponent",
+    },
+    ComponentKeys.STATUS: {
+        "description": "StatusComponent payload tracking timed effects such as poison, burns, or scars.",
+        "resource": &"StatusComponent",
+    },
+    ComponentKeys.SKILLS: {
+        "description": "SkillComponent manifest listing usable abilities and their metadata.",
+        "resource": &"SkillComponent",
+    },
+    ComponentKeys.INVENTORY: {
+        "description": "InventoryComponent reference detailing carried items and loot tables.",
+        "resource": &"InventoryComponent",
+    },
+    ComponentKeys.AI_BEHAVIOR: {
+        "description": "AIBehaviorComponent attachment specifying brain scripts or behaviour trees.",
+        "resource": &"AIBehaviorComponent",
+    },
+    ComponentKeys.FACTION: {
+        "description": "FactionComponent declaring allegiance identifiers and reputation dictionaries.",
+        "resource": &"FactionComponent",
+    },
+    ComponentKeys.QUEST_STATE: {
+        "description": "QuestStateComponent tracking quest lifecycle data for an entity.",
+        "resource": &"QuestStateComponent",
+    },
+}
+
+## Returns the symbolic label associated with an EntityType ID. Unknown IDs fall
+## back to `UNKNOWN_ENTITY_TYPE` so debug logs remain informative even when data
+## is malformed.
+static func get_entity_type_name(entity_type: int) -> StringName:
+    return _ENTITY_TYPE_NAMES.get(entity_type, &"UNKNOWN_ENTITY_TYPE")
+
+## Enumerates every declared EntityType value. Downstream systems can iterate the
+## array when building UI dropdowns or validation reports.
+static func list_entity_types() -> Array[int]:
+    return _ENTITY_TYPE_NAMES.keys()
+
+## Returns true when the provided integer maps to a declared EntityType.
+static func is_valid_entity_type(entity_type: int) -> bool:
+    return _ENTITY_TYPE_NAMES.has(entity_type)
+
+## Emits an editor error if the supplied value is not a recognised entity type.
+## Returns `true` when valid so the helper can be used inside `assert` chains.
+static func assert_valid_entity_type(entity_type: int) -> bool:
+    if not is_valid_entity_type(entity_type):
+        push_error(
+            "Enums: Unknown EntityType id %s. Expected one of: %s." % [
+                entity_type,
+                ", ".join(_ENTITY_TYPE_NAMES.values().map(func(name: StringName) -> String: return String(name))),
+            ]
+        )
+        return false
+    return true
+
+## Returns the metadata dictionary for a component key. Unknown keys produce an
+## empty dictionary so callers can detect missing definitions without risking
+## runtime errors.
+static func get_component_metadata(key: Variant) -> Dictionary:
+    var normalized := _normalize_component_key(key)
+    if normalized == StringName():
+        return {}
+    return COMPONENT_KEY_METADATA.get(normalized, {})
+
+## Returns a deep copy of the component metadata table for editor integrations
+## that need to present descriptions without risking accidental mutation.
+static func describe_all_components() -> Dictionary:
+    return COMPONENT_KEY_METADATA.duplicate(true)
+
+## Enumerates all registered component keys as `StringName` values.
+static func list_component_keys() -> Array[StringName]:
+    return COMPONENT_KEY_METADATA.keys()
+
+## Returns true when the provided key is recognised and non-empty.
+static func is_valid_component_key(key: Variant) -> bool:
+    var normalized := _normalize_component_key(key)
+    return normalized != StringName() and COMPONENT_KEY_METADATA.has(normalized)
+
+## Emits descriptive errors for component keys that fall outside the curated
+## registry. Returns `true` when the key is accepted so the helper can be used
+## as a guard clause.
+static func assert_valid_component_key(key: Variant) -> bool:
+    var normalized := _normalize_component_key(key)
+    if not COMPONENT_KEY_METADATA.has(normalized):
+        push_error(
+            "Enums: Unknown component key '%s'. Registered keys: %s." % [
+                key,
+                ", ".join(ComponentKeys.all()),
+            ]
+        )
+        return false
+    return true
+
+## Produces a structured diagnostic report for a components dictionary. Each
+## entry records whether the key is recognised, the value type, and any issues
+## detected so debug overlays can surface actionable feedback to engineers.
+static func inspect_component_dictionary(components: Dictionary) -> Dictionary:
+    var report := {}
+    for raw_key in components.keys():
+        var normalized := _normalize_component_key(raw_key)
+        var metadata := COMPONENT_KEY_METADATA.get(normalized, {})
+        var value := components[raw_key]
+        var entry := {
+            "normalized_key": String(normalized),
+            "recognized": not metadata.is_empty(),
+            "value_type": type_string(typeof(value)),
+            "resource_hint": metadata.get("resource", &""),
+            "description": metadata.get("description", ""),
+            "is_null": value == null,
+        }
+        if metadata.is_empty():
+            entry["issue"] = "Unregistered component key"
+        elif value == null:
+            entry["issue"] = "Component reference is null"
+        report[String(normalized)] = entry
+    return report
+
+## Runs validation across a components dictionary and returns any problems as a
+## list of human-readable messages. Upstream systems can log or assert on the
+## returned array to stop invalid payloads from propagating deeper into the game
+## loop.
+static func validate_component_dictionary(components: Dictionary) -> Array[String]:
+    var issues: Array[String] = []
+    for raw_key in components.keys():
+        var normalized := _normalize_component_key(raw_key)
+        if not COMPONENT_KEY_METADATA.has(normalized):
+            issues.append("Unknown component key '%s'." % raw_key)
+            continue
+        if components[raw_key] == null:
+            issues.append("Component '%s' is assigned a null resource." % normalized)
+    return issues
+
+static func _normalize_component_key(key: Variant) -> StringName:
+    if key is StringName:
+        return key
+    if key is String:
+        return StringName(key)
+    if key == null:
+        return StringName()
+    return StringName(str(key))


### PR DESCRIPTION
## Summary
- add a shared `Enums` autoload that exposes entity type enumerations and component key helpers with validation utilities
- wire `Enums` into the project autoload list so gameplay code can access the constants at runtime
- document a multi-phase plan for a consolidated autoload debugger that instruments EventBus, AssetRegistry, ModuleRegistry, and Enums

## Testing
- `godot --version` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ae983f7c832094b818e1f8d3d342