### PR TITLE
Fix DebugLogRedirector logger lookup

### DIFF
--- a/src/globals/DebugLogRedirector.gd
+++ b/src/globals/DebugLogRedirector.gd
@@ -1,6 +1,9 @@
 extends Node
 class_name DebugLogRedirectorSingleton
 
+## Engine singleton identifier used to locate the low-level logging interface.
+const LOGGER_SINGLETON_NAME := "Logger"
+
 ## Autoload singleton that intercepts Godot's global logger and forwards messages
 ## to the active DebugSystem instance. Designed for Godot 4.4.1.
 ##
@@ -53,9 +56,22 @@ func unregister_debug_system(system: Node) -> void:
     if _active_debug_system == null:
         return
 
-    var current := _active_debug_system.get_ref()
-    if not is_instance_valid(current) or current == system:
+    var current_object: Object = _active_debug_system.get_ref()
+    if not is_instance_valid(current_object) or current_object == system:
         _active_debug_system = null
+
+## Resolves the engine logger singleton when available.
+## Returns null when running in environments (such as stripped-down test harnesses)
+## that do not expose Godot's Logger interface.
+func _get_logger_singleton() -> Object:
+    if not Engine.has_singleton(LOGGER_SINGLETON_NAME):
+        return null
+
+    var logger_singleton: Object = Engine.get_singleton(LOGGER_SINGLETON_NAME)
+    if logger_singleton == null:
+        return null
+
+    return logger_singleton
 
 ## Installs a custom logger callback that relays messages to DebugSystem while
 ## preserving the engine's native logging behaviour. The implementation probes
@@ -66,18 +82,25 @@ func _install_logger() -> void:
     if _is_logger_installed:
         return
 
-    var set_callable := Callable(Logger, "set_log_func")
+    var logger: Object = _get_logger_singleton()
+    if logger == null:
+        push_warning(
+            "Logger singleton is unavailable; DebugLogRedirectorSingleton cannot intercept log output."
+        )
+        return
+
+    var set_callable: Callable = Callable(logger, "set_log_func")
     if not set_callable.is_valid():
         push_warning(
             "Logger.set_log_func is unavailable; DebugLogRedirectorSingleton cannot intercept log output."
         )
         return
 
-    var get_callable := Callable(Logger, "get_log_func")
+    var get_callable: Callable = Callable(logger, "get_log_func")
     if get_callable.is_valid():
-        var previous := get_callable.call()
-        if previous is Callable:
-            _previous_log_func = previous
+        var previous_result: Variant = get_callable.call()
+        if previous_result is Callable:
+            _previous_log_func = previous_result
 
     _logger_callable = Callable(self, "_on_log_message")
     set_callable.call(_logger_callable)
@@ -90,13 +113,15 @@ func _uninstall_logger() -> void:
     if not _is_logger_installed:
         return
 
-    var set_callable := Callable(Logger, "set_log_func")
-    if set_callable.is_valid():
-        if _previous_log_func.is_valid():
-            set_callable.call(_previous_log_func)
-        else:
-            set_callable.call(Callable())
-
+    var logger: Object = _get_logger_singleton()
+    if logger != null:
+        var set_callable: Callable = Callable(logger, "set_log_func")
+        if set_callable.is_valid():
+            if _previous_log_func.is_valid():
+                set_callable.call(_previous_log_func)
+            else:
+                set_callable.call(Callable())
+    
     _is_logger_installed = false
     _logger_callable = Callable()
     _previous_log_func = Callable()
@@ -108,18 +133,23 @@ func _resolve_active_debug_system() -> Node:
     if _active_debug_system == null:
         return null
 
-    var instance := _active_debug_system.get_ref()
-    if not is_instance_valid(instance):
+    var instance_object: Object = _active_debug_system.get_ref()
+    if not is_instance_valid(instance_object):
         _active_debug_system = null
         return null
 
-    return instance
+    var instance_node: Node = instance_object as Node
+    if instance_node == null:
+        _active_debug_system = null
+        return null
+
+    return instance_node
 
 ## Custom logger callback wired into Godot's logging pipeline. The redirector
 ## forwards each message to the active DebugSystem (if available) and then invokes
 ## the original logger callback so standard console output remains intact.
 func _on_log_message(message: String, level: int, category: String, timestamp: String) -> void:
-    var debug_system := _resolve_active_debug_system()
+    var debug_system: Node = _resolve_active_debug_system()
     if debug_system and debug_system.has_method("capture_log_message"):
         debug_system.capture_log_message(message, level, category, timestamp)
 


### PR DESCRIPTION
## Summary
- resolve the DebugLogRedirector autoload against Godot's Logger singleton via Engine.has_singleton/Engine.get_singleton
- tighten type hints around weak references and callable lookups so the redirector no longer infers Variant types
- guard log installation/uninstallation to degrade gracefully when the logger interface is unavailable (e.g. in stripped-down runners)

## Testing
- `godot4 --headless --path . --run-tests` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ef4d53688320880650eda8ae84c6