### PR TITLE
Fix StatsComponent parsing and debug helpers

### DIFF
--- a/devdocs/Designers/StatsComponentManual.md
+++ b/devdocs/Designers/StatsComponentManual.md
@@ -83,7 +83,7 @@ Each section groups related properties. "Common range" records the values most b
 | Property | Type | Description | Common range & notes |
 | --- | --- | --- | --- |
 | `skill_levels` | `Dictionary[StringName, int]` | Tracks each learned skill's tier (basic/common/rare/etc.).【F:src/components/StatsComponent.gd†L155-L158】 | Store 3–8 skills for early heroes, expanding toward 12 for veterans. Values typically map to 0–4 representing rarity tiers.【F:BaseCharacterStats.md†L95-L123】 |
-| `skill_options` | `Dictionary[StringName, Array[StringName]]` | Lists unlocked options or upgrades per skill tree.【F:src/components/StatsComponent.gd†L160-L163】 | Each skill carries 1–3 unlocked options mid-game; complex trees may hit 5. Arrays should stay ordered for deterministic UI.【F:BaseCharacterStats.md†L95-L123】 |
+| `skill_options` | `Dictionary[StringName, Array]` | Lists unlocked options or upgrades per skill tree. Arrays should contain `StringName` entries even though the exported type is untyped to satisfy Godot's parser.【F:src/components/StatsComponent.gd†L125-L128】 | Each skill carries 1–3 unlocked options mid-game; complex trees may hit 5. Arrays should stay ordered for deterministic UI.【F:BaseCharacterStats.md†L95-L123】 |
 
 ## Equipment and inventory snapshots
 

--- a/src/components/StatsComponent.gd
+++ b/src/components/StatsComponent.gd
@@ -123,7 +123,9 @@ class_name StatsComponent
 @export var skill_levels: Dictionary[StringName, int] = {}
 
 ## Mapping of skill identifiers to unlocked option identifiers within each skill tree.
-@export var skill_options: Dictionary[StringName, Array[StringName]] = {}
+## Godot 4.4.1 does not support nested generic type hints (Dictionary[StringName, Array[StringName]]),
+## so we export a Dictionary[StringName, Array] and document that each Array should contain StringName values.
+@export var skill_options: Dictionary[StringName, Array] = {}
 
 ## ---- Equipment Snapshot ----
 ## Mapping of equipment slot identifiers (e.g., "weapon", "armor") to equipped item IDs.


### PR DESCRIPTION
## Summary
- remove the nested generic export from `StatsComponent` to satisfy the Godot 4.4.1 parser and document the expectation in the designer manual
- rely on the base `System` constant in `DebugSystem`, add a local ASCII helper, and tighten Variant-heavy call sites to satisfy strict typing

## Testing
- godot --headless --path . --run-tests --test junit --output tests/results.xml *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca0168dab48320be1188993ab36055