### PR TITLE
Add Codex Godot process manager and tests

### DIFF
--- a/devdocs/CodexAutomation.md
+++ b/devdocs/CodexAutomation.md
@@ -1,0 +1,72 @@
+# Codex Automation Process Manager
+
+The `tools/codex_godot_process_manager.py` module provides the Python-facing
+wrapper that Codex uses to launch and supervise headless Godot sessions.  It
+is designed to follow the communication and orchestration guidelines described
+in the "Python Godot Automation Design Bible" so that outside engineers can
+easily integrate Codex-driven automation into their own tooling.
+
+## Environment variables
+
+Two environment variables define the default launch configuration:
+
+- `CODEX_GODOT_BIN`: Absolute path to the Godot 4 executable to run.  The
+  module will refuse to start if this is not provided either via the
+  environment or the class constructor.
+- `CODEX_PROJECT_ROOT`: Path to the Godot project that should be mounted via
+  `--path`.  This directory must contain the canonical `project.godot` file.
+
+Both variables can be overridden by passing explicit values to the
+`CodexGodotProcessManager` constructor.  Manual operators often provide custom
+arguments or environment tweaks while Codex production runs typically rely on
+CI provided defaults.
+
+## Session lifecycle
+
+```python
+from tools.codex_godot_process_manager import CodexGodotProcessManager
+
+with CodexGodotProcessManager(extra_args=["-s", "res://tests/run_all_tests.gd"]) as manager:
+    # Send JSON-RPC commands and iterate over responses.
+    request_id = manager.send_command("scenario.load", {"name": "Arena"})
+    for message in manager.iter_messages(timeout=1.0):
+        print(message)
+```
+
+- `start()` launches `godot --headless --path <project>` with the configured
+  arguments and immediately sends an automatic `codex.banner` negotiation
+  request.  The response is captured and surfaced via
+  `manager.describe_session().banner`.
+- `stop()` gracefully terminates the process and joins the reader threads.  A
+  context manager (`with` block) is provided for convenience.
+
+## Communication model
+
+- Commands are serialized as JSON-RPC style dictionaries with a monotonically
+  increasing `id`, a `method` string, and a `params` dictionary.  Each command
+  is written as a single newline-delimited JSON document on stdin.
+- Responses are consumed through `iter_messages()`, which parses each newline
+  from stdout and yields decoded dictionaries.  The banner response is
+  consumed internally so user code only sees domain-specific payloads.
+- Any stdout line that fails JSON parsing or every stderr line is converted
+  into a structured diagnostic record.  These records can be inspected via
+  `iter_stderr_diagnostics()` and include timestamps, severity levels, and the
+  originating stream.
+
+## Heartbeat and timeout handling
+
+Codex runs are often unattended, so the manager includes a lightweight
+heartbeat monitor.  When `heartbeat_interval` is provided the manager wakes up
+periodically to check when the last stdout message was seen.  If the elapsed
+silence exceeds `heartbeat_timeout` (defaults to the interval) a warning
+record with `stream="heartbeat"` is injected into the diagnostics queue.
+This allows Codex to detect hung scenarios without preventing manual
+operators from running longer experiments (set the interval to `None` to
+disable the watchdog).
+
+## Introspection
+
+`describe_session()` returns a `SessionDescription` dataclass containing the
+active command line, process ID, negotiated banner, and heartbeat settings.
+This makes it straightforward to mirror Codex' perspective on a live session
+when debugging in external tooling or when collecting telemetry for CI.

--- a/python_tests/test_codex_godot_process_manager.py
+++ b/python_tests/test_codex_godot_process_manager.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import io
+import json
+import time
+from pathlib import Path
+from typing import Iterable
+from unittest import mock
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from tools.codex_godot_process_manager import CodexGodotProcessManager
+
+
+class FakeProcess:
+    def __init__(self, stdout_lines: Iterable[str], stderr_lines: Iterable[str] | None = None):
+        self.stdin = io.StringIO()
+        self.stdout = io.StringIO("\n".join(stdout_lines) + ("\n" if stdout_lines else ""))
+        stderr_lines = list(stderr_lines or [])
+        self.stderr = io.StringIO("\n".join(stderr_lines) + ("\n" if stderr_lines else ""))
+        self.pid = 4242
+        self._returncode = None
+
+    def poll(self):
+        return self._returncode
+
+    def wait(self, timeout=None):  # pragma: no cover - unused in tests
+        self._returncode = 0
+        return 0
+
+    def terminate(self):  # pragma: no cover - unused in tests
+        self._returncode = 0
+
+    def kill(self):  # pragma: no cover - unused in tests
+        self._returncode = -9
+
+
+@pytest.fixture(autouse=True)
+def _set_env(monkeypatch):
+    monkeypatch.setenv("CODEX_GODOT_BIN", "godot")
+    monkeypatch.setenv("CODEX_PROJECT_ROOT", "/project")
+
+
+def test_start_sends_banner_request(monkeypatch):
+    process = FakeProcess(["{\"id\":0,\"result\":{\"banner\":\"ok\"}}"])
+    monkeypatch.setattr("subprocess.Popen", mock.Mock(return_value=process))
+
+    manager = CodexGodotProcessManager()
+    manager.start()
+
+    lines = [json.loads(line) for line in process.stdin.getvalue().splitlines()]
+    assert lines[0]["method"] == "codex.banner"
+    assert lines[0]["params"]["client"] == "codex"
+
+    command_id = manager.send_command("scene.load", {"path": "res://test.tscn"})
+    assert command_id == 1
+    assert json.loads(process.stdin.getvalue().splitlines()[-1]) == {
+        "id": 1,
+        "method": "scene.load",
+        "params": {"path": "res://test.tscn"},
+    }
+
+    manager.stop()
+
+
+def test_iter_messages_skips_banner(monkeypatch):
+    process = FakeProcess(
+        [
+            "{\"id\":0,\"result\":{\"banner\":\"hello\"}}",
+            "{\"id\":1,\"result\":{\"ok\":true}}",
+        ]
+    )
+    monkeypatch.setattr("subprocess.Popen", mock.Mock(return_value=process))
+
+    manager = CodexGodotProcessManager()
+    manager.start()
+
+    iterator = manager.iter_messages(timeout=0.1)
+    message = next(iterator)
+    assert message == {"id": 1, "result": {"ok": True}}
+
+    description = manager.describe_session()
+    assert description.banner == {"banner": "hello"}
+
+    manager.stop()
+
+
+def test_diagnostics_surface_for_non_json(monkeypatch):
+    process = FakeProcess(
+        [
+            "{\"id\":0,\"result\":{\"banner\":\"banner\"}}",
+            "not json",
+            "{\"id\":1,\"result\":42}",
+        ],
+        stderr_lines=["engine: warning"],
+    )
+    monkeypatch.setattr("subprocess.Popen", mock.Mock(return_value=process))
+
+    manager = CodexGodotProcessManager()
+    manager.start()
+
+    iterator = manager.iter_messages(timeout=0.1)
+    assert next(iterator)["result"] == 42
+
+    time.sleep(0.05)
+    manager.stop()
+
+    diagnostics = list(manager.iter_stderr_diagnostics())
+    assert any(entry["stream"] == "stdout" and entry["level"] == "protocol" for entry in diagnostics)
+    assert any(entry["stream"] == "stderr" and entry["text"].startswith("engine") for entry in diagnostics)
+
+    manager.stop()
+
+
+def test_heartbeat_timeout_emits_diagnostic(monkeypatch):
+    process = FakeProcess(["{\"id\":0,\"result\":{\"banner\":\"b\"}}"])
+    monkeypatch.setattr("subprocess.Popen", mock.Mock(return_value=process))
+
+    manager = CodexGodotProcessManager(heartbeat_interval=0.05, heartbeat_timeout=0.01)
+    manager.start()
+
+    time.sleep(0.1)
+    manager.stop()
+
+    diagnostics = list(manager.iter_stderr_diagnostics())
+    assert any(entry["stream"] == "heartbeat" for entry in diagnostics)
+
+    manager.stop()

--- a/tools/codex_godot_process_manager.py
+++ b/tools/codex_godot_process_manager.py
@@ -1,0 +1,408 @@
+"""Process management helpers for Codex driven Godot sessions.
+
+This module exposes :class:`CodexGodotProcessManager`, a small orchestration
+utility that wraps :class:`subprocess.Popen` with sensible defaults for the
+Codex automation workflows described in the "Python Godot Automation Design
+Bible".  The class is intentionally light-weight – it focuses on starting a
+headless Godot instance, ensuring JSON-RPC style communication via
+line-delimited messages, and surfacing diagnostics that are useful when the
+engine misbehaves.
+
+The behaviour of the process manager can be tweaked via a small set of
+environment variables:
+
+``CODEX_GODOT_BIN``
+    Absolute path to the Godot executable that should be launched when a new
+    session is created.
+``CODEX_PROJECT_ROOT``
+    Filesystem path that will be passed to the ``--path`` flag when starting
+    Godot.  This must contain the ``project.godot`` manifest.
+
+These defaults can be overridden programmatically when instantiating
+:class:`CodexGodotProcessManager` which keeps the API flexible for local
+experimenters and automated Codex operators alike.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Dict, Generator, Iterable, List, Optional
+
+
+@dataclass
+class SessionDescription:
+    """Describes an active Codex managed Godot session."""
+
+    session_id: str
+    pid: Optional[int]
+    command: List[str]
+    project_root: str
+    banner: Optional[dict] = None
+    heartbeat_interval: Optional[float] = None
+    heartbeat_timeout: Optional[float] = None
+
+
+class CodexGodotProcessManager:
+    """Manage the lifecycle of a headless Godot process for Codex automation.
+
+    Parameters
+    ----------
+    godot_binary:
+        Path to the Godot executable.  Defaults to the ``CODEX_GODOT_BIN``
+        environment variable.
+    project_root:
+        Path to the Godot project that will be supplied via ``--path``.
+        Defaults to the ``CODEX_PROJECT_ROOT`` environment variable.
+    extra_args:
+        Additional command line arguments forwarded to Godot.
+    env_overrides:
+        Optional environment overrides that are merged with the inherited
+        environment.
+    heartbeat_interval:
+        Optional number of seconds between heartbeat checks.  When provided a
+        lightweight monitor thread will emit timeout diagnostics whenever no
+        stdout message is observed for longer than ``heartbeat_timeout``.
+    heartbeat_timeout:
+        Number of seconds to tolerate without receiving a message before a
+        heartbeat diagnostic is published.  When omitted it defaults to
+        ``heartbeat_interval`` if that is set.
+    banner_timeout:
+        Maximum number of seconds to wait for the banner response that is
+        negotiated automatically when the session starts.
+    """
+
+    #: Method invoked automatically to negotiate a banner for Codex sessions.
+    _BANNER_METHOD = "codex.banner"
+
+    def __init__(
+        self,
+        *,
+        godot_binary: Optional[str] = None,
+        project_root: Optional[str] = None,
+        extra_args: Optional[Iterable[str]] = None,
+        env_overrides: Optional[Dict[str, str]] = None,
+        heartbeat_interval: Optional[float] = None,
+        heartbeat_timeout: Optional[float] = None,
+        banner_timeout: float = 5.0,
+    ) -> None:
+        self.godot_binary = godot_binary or os.environ.get("CODEX_GODOT_BIN")
+        self.project_root = project_root or os.environ.get("CODEX_PROJECT_ROOT")
+        if not self.godot_binary:
+            raise ValueError(
+                "Godot binary not provided. Set CODEX_GODOT_BIN or pass godot_binary."
+            )
+        if not self.project_root:
+            raise ValueError(
+                "Project root not provided. Set CODEX_PROJECT_ROOT or pass project_root."
+            )
+
+        self.extra_args = list(extra_args or [])
+        self.env_overrides = dict(env_overrides or {})
+        self.heartbeat_interval = heartbeat_interval
+        self.heartbeat_timeout = (
+            heartbeat_timeout if heartbeat_timeout is not None else heartbeat_interval
+        )
+        self.banner_timeout = banner_timeout
+
+        self._process: Optional[subprocess.Popen[str]] = None
+        self._stdout_thread: Optional[threading.Thread] = None
+        self._stderr_thread: Optional[threading.Thread] = None
+        self._heartbeat_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._stdout_queue: "queue.Queue[str | None]" = queue.Queue()
+        self._stderr_queue: "queue.Queue[dict | None]" = queue.Queue()
+        self._id_counter = 1
+        self._banner_request_id: Optional[int] = None
+        self._banner: Optional[dict] = None
+        self._session_id = str(uuid.uuid4())
+        self._last_activity = time.monotonic()
+
+    # ------------------------------------------------------------------
+    # Context manager support
+    def __enter__(self) -> "CodexGodotProcessManager":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()
+
+    # ------------------------------------------------------------------
+    # Public API
+    @property
+    def is_running(self) -> bool:
+        return bool(self._process and self._process.poll() is None)
+
+    def start(self) -> None:
+        """Start the Godot process and associated reader threads."""
+
+        if self.is_running:
+            return
+
+        env = os.environ.copy()
+        env.update(self.env_overrides)
+
+        command = [
+            self.godot_binary,
+            "--headless",
+            "--path",
+            self.project_root,
+        ] + self.extra_args
+
+        self._process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+            env=env,
+        )
+
+        assert self._process.stdout is not None  # for type-checkers
+        assert self._process.stderr is not None
+        assert self._process.stdin is not None
+
+        self._stop_event.clear()
+        self._stdout_thread = threading.Thread(
+            target=self._reader_thread,
+            args=(self._process.stdout, self._stdout_queue, "stdout"),
+            daemon=True,
+        )
+        self._stderr_thread = threading.Thread(
+            target=self._reader_thread,
+            args=(self._process.stderr, self._stderr_queue, "stderr"),
+            daemon=True,
+        )
+        self._stdout_thread.start()
+        self._stderr_thread.start()
+
+        self._banner_request_id = self.send_command(
+            self._BANNER_METHOD,
+            {
+                "client": "codex",
+                "session": self._session_id,
+                "protocol": "json-rpc",
+            },
+            id_override=0,
+        )
+
+        if self.heartbeat_interval:
+            self._heartbeat_thread = threading.Thread(
+                target=self._heartbeat_monitor,
+                name="CodexGodotHeartbeat",
+                daemon=True,
+            )
+            self._heartbeat_thread.start()
+
+    def stop(self) -> None:
+        """Terminate the Godot process and wait for reader threads to exit."""
+
+        self._stop_event.set()
+        if not self._process:
+            return
+
+        if self._process.stdin and not self._process.stdin.closed:
+            try:
+                self._process.stdin.flush()
+                self._process.stdin.close()
+            except Exception:
+                pass
+
+        if self.is_running:
+            try:
+                self._process.terminate()
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait(timeout=5)
+
+        if self._stdout_thread and self._stdout_thread.is_alive():
+            self._stdout_thread.join(timeout=1)
+        if self._stderr_thread and self._stderr_thread.is_alive():
+            self._stderr_thread.join(timeout=1)
+        if self._heartbeat_thread and self._heartbeat_thread.is_alive():
+            self._heartbeat_thread.join(timeout=1)
+
+        self._process = None
+
+    def describe_session(self) -> SessionDescription:
+        """Return a snapshot of the currently running session."""
+
+        command: List[str] = [
+            self.godot_binary,
+            "--headless",
+            "--path",
+            self.project_root,
+        ] + self.extra_args
+        pid = self._process.pid if self._process else None
+        return SessionDescription(
+            session_id=self._session_id,
+            pid=pid,
+            command=command,
+            project_root=self.project_root,
+            banner=self._banner,
+            heartbeat_interval=self.heartbeat_interval,
+            heartbeat_timeout=self.heartbeat_timeout,
+        )
+
+    # Communication helpers -------------------------------------------------
+    def send_command(
+        self,
+        method: str,
+        params: Optional[dict] = None,
+        *,
+        id_override: Optional[int] = None,
+    ) -> int:
+        """Send a JSON-RPC style command to the running Godot process."""
+
+        if not self.is_running or not self._process or not self._process.stdin:
+            raise RuntimeError("Godot process is not running.")
+
+        request_id = id_override if id_override is not None else self._id_counter
+        self._id_counter = max(self._id_counter, request_id + 1)
+
+        payload = {
+            "id": request_id,
+            "method": method,
+            "params": params or {},
+        }
+        message = json.dumps(payload, separators=(",", ":")) + "\n"
+        try:
+            self._process.stdin.write(message)
+            self._process.stdin.flush()
+        except (BrokenPipeError, ValueError) as error:  # pragma: no cover - I/O failure
+            raise RuntimeError("Failed to send command to Godot process") from error
+
+        return request_id
+
+    def iter_messages(
+        self,
+        *,
+        timeout: Optional[float] = None,
+    ) -> Generator[dict, None, None]:
+        """Yield parsed JSON messages produced by the Godot process.
+
+        The iterator consumes responses from the stdout queue.  It silently
+        handles the banner response that is negotiated automatically during
+        :meth:`start`.  Non-JSON lines are treated as diagnostics and will be
+        surfaced via :meth:`iter_stderr_diagnostics` with structured metadata.
+        """
+
+        if not self.is_running:
+            raise RuntimeError("Godot process is not running.")
+
+        while True:
+            try:
+                line = self._stdout_queue.get(timeout=timeout)
+            except queue.Empty:
+                self._maybe_emit_heartbeat_timeout()
+                continue
+
+            if line is None:
+                break
+
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            try:
+                message = json.loads(stripped)
+            except json.JSONDecodeError:
+                self._stderr_queue.put(
+                    {
+                        "timestamp": time.time(),
+                        "stream": "stdout",
+                        "text": stripped,
+                        "level": "protocol",
+                    }
+                )
+                continue
+
+            self._last_activity = time.monotonic()
+
+            if self._banner_request_id is not None and message.get("id") == self._banner_request_id:
+                banner_payload = message.get("result")
+                if isinstance(banner_payload, dict):
+                    self._banner = banner_payload
+                else:
+                    self._banner = {"message": banner_payload}
+                self._banner_request_id = None
+                continue
+
+            yield message
+
+    def iter_stderr_diagnostics(self) -> Generator[dict, None, None]:
+        """Yield structured diagnostics that originated from stderr or decoding errors."""
+
+        while True:
+            try:
+                payload = self._stderr_queue.get(timeout=0.1)
+            except queue.Empty:
+                if not self.is_running and self._stderr_queue.empty():
+                    return
+                if self._stop_event.is_set():
+                    return
+                continue
+
+            if payload is None:
+                if not self.is_running and self._stderr_queue.empty():
+                    return
+                continue
+            yield payload
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _reader_thread(self, pipe, sink: "queue.Queue", source: str) -> None:
+        try:
+            for raw_line in iter(pipe.readline, ""):
+                if self._stop_event.is_set():
+                    break
+                if source == "stdout":
+                    sink.put(raw_line.rstrip("\n"))
+                else:
+                    sink.put(
+                        {
+                            "timestamp": time.time(),
+                            "stream": source,
+                            "text": raw_line.rstrip("\n"),
+                            "level": "error",
+                        }
+                    )
+        finally:
+            sink.put(None)
+            pipe.close()
+
+    def _heartbeat_monitor(self) -> None:
+        assert self.heartbeat_interval is not None
+        while not self._stop_event.wait(self.heartbeat_interval):
+            if not self.is_running:
+                break
+            self._maybe_emit_heartbeat_timeout()
+
+    def _maybe_emit_heartbeat_timeout(self) -> None:
+        if not self.heartbeat_timeout:
+            return
+        elapsed = time.monotonic() - self._last_activity
+        if elapsed < self.heartbeat_timeout:
+            return
+        diagnostic = {
+            "timestamp": time.time(),
+            "stream": "heartbeat",
+            "text": f"No stdout messages for {elapsed:.2f}s",
+            "level": "warning",
+            "session": self._session_id,
+        }
+        self._stderr_queue.put(diagnostic)
+        self._last_activity = time.monotonic()
+
+
+__all__ = ["CodexGodotProcessManager", "SessionDescription"]


### PR DESCRIPTION
## Summary
- add a CodexGodotProcessManager helper that launches Godot with sensible defaults, negotiates a banner, and manages heartbeat diagnostics
- expose structured stderr diagnostics and JSON-RPC helpers for Codex automation sessions
- document configuration knobs and add mock-based smoke tests for message framing

## Testing
- pytest python_tests

------
https://chatgpt.com/codex/tasks/task_e_68cba064b094832095438e3d93247b42