### PR TITLE
Add EventBus replay runner and Codex wrapper

### DIFF
--- a/devdocs/CodexAutomation.md
+++ b/devdocs/CodexAutomation.md
@@ -70,3 +70,37 @@ disable the watchdog).
 active command line, process ID, negotiated banner, and heartbeat settings.
 This makes it straightforward to mirror Codex' perspective on a live session
 when debugging in external tooling or when collecting telemetry for CI.
+
+## EventBus replay troubleshooting
+
+Codex replays EventBus transcripts by launching the headless runner at
+`res://tests/eventbus_replay_runner.gd`.  The script instantiates the harness
+scene, validates the JSON transcript, and calls
+`EventBusHarness.replay_signals_from_json()` so every entry is exercised against
+the live EventBus contracts.  Outcomes are streamed as newline-delimited JSON
+records that Codex aggregates into a report.  Manual engineers can mirror the
+same workflow by running:
+
+```bash
+godot4 --headless --path <project> --script res://tests/eventbus_replay_runner.gd <path/to/replay.json>
+```
+
+The transcript must be a JSON array of dictionaries.  Each entry requires a
+`signal_name` string and a `payload` dictionary; additional metadata keys are
+ignored.  Any structural issue (missing keys, non-dictionary payloads, malformed
+JSON) triggers a fast-fail diagnostic before Godot emits the replay, preventing
+partial runs from masking schema drift.
+
+For automation, `tools/codex_replay_eventbus.py` wraps the process manager so
+Codex can collect structured results.  The helper accepts the replay path plus
+optional `--export-log` and `--echo-log` flags to persist or mirror the harness
+log.  It parses every `eventbus_replay_*` JSON line into a machine-readable
+report that downstream systems or engineers can inspect without scraping human
+text.  The module also exposes a `format_report()` utility to render the results
+in a human-friendly summary when troubleshooting locally.
+
+When diagnosing failures, enable the echo flag to capture the harness transcript
+alongside Codex' summary, or export the log to disk for attachment to bug
+reports.  Because the runner reuses the same harness logic that powers the
+in-editor tooling, reproducing Codex' steps manually ensures parity between CI
+and local debugging.

--- a/tests/eventbus_replay_runner.gd
+++ b/tests/eventbus_replay_runner.gd
@@ -1,0 +1,366 @@
+extends SceneTree
+
+const HARNESS_SCENE := preload("res://tests/EventBus_TestHarness.tscn")
+const EXIT_SUCCESS := 0
+const EXIT_FAILURE := 1
+
+func _init() -> void:
+    call_deferred("_run")
+
+func _run() -> void:
+    var args := _parse_arguments(OS.get_cmdline_args())
+    if args["help"]:
+        _print_usage()
+        quit(EXIT_SUCCESS)
+        return
+
+    if not args["errors"].is_empty():
+        for error_message in args["errors"]:
+            push_error(error_message)
+            _emit_json({
+                "type": "eventbus_replay_error",
+                "message": error_message,
+            })
+        quit(EXIT_FAILURE)
+        return
+
+    var replay_path: String = args["replay_path"]
+    if replay_path.is_empty():
+        var missing_path := "Replay transcript path is required."
+        push_error(missing_path)
+        _emit_json({
+            "type": "eventbus_replay_error",
+            "message": missing_path,
+        })
+        _print_usage()
+        quit(EXIT_FAILURE)
+        return
+
+    var normalized_replay_path := _normalize_path(replay_path)
+    var load_result := _load_replay_entries(normalized_replay_path)
+    if load_result.has("error"):
+        var load_error: String = load_result["error"]
+        push_error(load_error)
+        _emit_json({
+            "type": "eventbus_replay_error",
+            "message": load_error,
+        })
+        quit(EXIT_FAILURE)
+        return
+
+    var entries: Array = load_result["entries"]
+
+    var harness_root: Node = HARNESS_SCENE.instantiate()
+    get_root().add_child(harness_root)
+    await harness_root.ready
+
+    var log_label := _resolve_log_label(harness_root)
+    if log_label == null:
+        var log_error := "EventBusHarness log label could not be resolved."
+        push_error(log_error)
+        _emit_json({
+            "type": "eventbus_replay_error",
+            "message": log_error,
+        })
+        quit(EXIT_FAILURE)
+        return
+
+    var previous_log_lines := _split_lines(log_label.get_parsed_text())
+
+    harness_root.call("replay_signals_from_json", entries)
+    await process_frame
+    await process_frame
+
+    var current_log_lines := _split_lines(log_label.get_parsed_text())
+    var new_lines: Array = []
+    if current_log_lines.size() > previous_log_lines.size():
+        new_lines = current_log_lines.slice(previous_log_lines.size(), current_log_lines.size())
+
+    var entry_index := 0
+    var success_count := 0
+    var failure_count := 0
+    var skipped_count := 0
+    var general_messages: Array = []
+
+    for raw_line in new_lines:
+        var parsed := _parse_log_line(raw_line)
+        match parsed.get("kind", "message"):
+            "entry":
+                entry_index += 1
+                var entry_payload: Dictionary = parsed["payload"].duplicate()
+                entry_payload["index"] = entry_index
+                _emit_json(entry_payload)
+                match entry_payload.get("status", "info"):
+                    "ok":
+                        success_count += 1
+                    "skipped":
+                        skipped_count += 1
+                    "error":
+                        failure_count += 1
+                continue
+            _:
+                general_messages.append(parsed.get("message", ""))
+                _emit_json({
+                    "type": "eventbus_replay_log",
+                    "timestamp": parsed.get("timestamp", ""),
+                    "message": parsed.get("message", ""),
+                    "level": parsed.get("level", "info"),
+                })
+
+    if args["export_log_path"] is String and not String(args["export_log_path"]).is_empty():
+        var export_path := _normalize_path(String(args["export_log_path"]))
+        var export_error := harness_root.call("export_log", export_path)
+        if export_error != OK:
+            var export_message := "Failed to export harness log to %s (error %s)." % [
+                export_path,
+                error_string(export_error),
+            ]
+            push_error(export_message)
+            _emit_json({
+                "type": "eventbus_replay_error",
+                "message": export_message,
+            })
+        else:
+            _emit_json({
+                "type": "eventbus_replay_log_export",
+                "path": export_path,
+            })
+
+    var combined_log_text := log_label.get_parsed_text()
+    if args["echo_log"]:
+        _emit_json({
+            "type": "eventbus_replay_echo",
+            "text": combined_log_text,
+        })
+
+    harness_root.queue_free()
+    await process_frame
+
+    var total_entries := success_count + failure_count + skipped_count
+    var had_failure := failure_count > 0 or skipped_count > 0 or total_entries == 0
+    var summary := {
+        "type": "eventbus_replay_summary",
+        "total": total_entries,
+        "succeeded": success_count,
+        "failed": failure_count,
+        "skipped": skipped_count,
+        "messages": general_messages,
+        "exit_code": EXIT_SUCCESS if not had_failure else EXIT_FAILURE,
+    }
+    _emit_json(summary)
+
+    quit(summary["exit_code"])
+
+func _parse_arguments(args: Array) -> Dictionary:
+    var result := {
+        "replay_path": "",
+        "export_log_path": "",
+        "echo_log": false,
+        "errors": [],
+        "help": false,
+    }
+
+    var expect_value_for := ""
+    for raw_arg in args:
+        var arg := String(raw_arg)
+        if not expect_value_for.is_empty():
+            result[expect_value_for] = arg
+            expect_value_for = ""
+            continue
+
+        match arg:
+            "-h", "--help":
+                result["help"] = true
+            "--echo-log":
+                result["echo_log"] = true
+            "--export-log":
+                expect_value_for = "export_log_path"
+            _:
+                if arg.begins_with("--export-log="):
+                    result["export_log_path"] = arg.substr("--export-log=".length())
+                elif arg.begins_with("-"):
+                    result["errors"].append("Unknown flag: %s" % arg)
+                elif result["replay_path"].is_empty():
+                    result["replay_path"] = arg
+                else:
+                    result["errors"].append("Unexpected positional argument: %s" % arg)
+
+    if not expect_value_for.is_empty():
+        result["errors"].append("Flag --export-log requires a value.")
+
+    return result
+
+func _normalize_path(path: String) -> String:
+    if _is_absolute_path(path):
+        return path
+    if path.begins_with("res://") or path.begins_with("user://"):
+        return path
+    var project_root := ProjectSettings.globalize_path("res://")
+    return project_root.path_join(path)
+
+func _is_absolute_path(path: String) -> bool:
+    if path.is_empty():
+        return false
+    if path.begins_with("/"):
+        return true
+    if path.length() > 2 and path[1] == ":" and (path[2] == "/" or path[2] == "\\"):
+        return true
+    return false
+
+func _load_replay_entries(path: String) -> Dictionary:
+    if not FileAccess.file_exists(path):
+        return {"error": "Replay transcript not found at %s" % path}
+
+    var file := FileAccess.open(path, FileAccess.READ)
+    if file == null:
+        return {"error": "Unable to open replay transcript at %s" % path}
+
+    var contents := file.get_as_text()
+    file.close()
+
+    var json := JSON.new()
+    var parse_error := json.parse(contents)
+    if parse_error != OK:
+        return {
+            "error": "Failed to parse replay JSON at line %d: %s" % [
+                json.get_error_line(),
+                json.get_error_message(),
+            ]
+        }
+
+    var data := json.data
+    if typeof(data) != TYPE_ARRAY:
+        return {"error": "Replay JSON root must be an array of dictionaries."}
+
+    var validation := _validate_entries(data)
+    if validation.has("error"):
+        return validation
+
+    return {"entries": validation["entries"]}
+
+func _validate_entries(entries: Array) -> Dictionary:
+    var sanitized: Array = []
+    for i in range(entries.size()):
+        var entry_variant: Variant = entries[i]
+        if typeof(entry_variant) != TYPE_DICTIONARY:
+            return {"error": "Replay entry %d must be a dictionary." % (i + 1)}
+        var entry := (entry_variant as Dictionary).duplicate(true)
+
+        if not entry.has("signal_name"):
+            return {"error": "Replay entry %d is missing \"signal_name\"." % (i + 1)}
+        var raw_signal_name: Variant = entry["signal_name"]
+        match typeof(raw_signal_name):
+            TYPE_STRING, TYPE_STRING_NAME:
+                entry["signal_name"] = String(raw_signal_name)
+            _:
+                return {
+                    "error": "Replay entry %d has non-string signal_name." % (i + 1)
+                }
+
+        if not entry.has("payload"):
+            return {"error": "Replay entry %d is missing \"payload\"." % (i + 1)}
+        var payload_variant: Variant = entry["payload"]
+        if typeof(payload_variant) != TYPE_DICTIONARY:
+            return {
+                "error": "Replay entry %d payload must be a dictionary." % (i + 1)
+            }
+
+        sanitized.append(entry)
+
+    return {"entries": sanitized}
+
+func _resolve_log_label(harness: Node) -> RichTextLabel:
+    if harness == null:
+        return null
+    var label := harness.get_node_or_null("%Log")
+    if label == null:
+        label = harness.get_node_or_null("Log")
+    return label as RichTextLabel
+
+func _split_lines(text: String) -> Array:
+    if text.is_empty():
+        return []
+    var lines: Array = text.split("\n")
+    if lines.size() > 0 and String(lines[-1]) == "":
+        lines.pop_back()
+    return lines
+
+func _parse_log_line(line: String) -> Dictionary:
+    var stripped := line.strip_edges()
+    var timestamp := ""
+    var message := stripped
+    if stripped.begins_with("["):
+        var closing := stripped.find("]")
+        if closing > 0:
+            timestamp = stripped.substr(1, closing - 1)
+            if closing + 2 <= stripped.length():
+                message = stripped.substr(closing + 2, stripped.length())
+    if message.begins_with("Replayed "):
+        return {
+            "kind": "entry",
+            "payload": _parse_success_entry(message, timestamp),
+        }
+    if message.begins_with("Failed to replay "):
+        return {
+            "kind": "entry",
+            "payload": _parse_failure_entry(message, timestamp),
+        }
+    if message.begins_with("Replay entry ") and message.find("skipping") != -1:
+        return {
+            "kind": "entry",
+            "payload": _parse_skipped_entry(message, timestamp),
+        }
+    var level := "info"
+    if message.findn("failed") != -1 or message.findn("unable") != -1:
+        level = "error"
+    return {
+        "kind": "message",
+        "timestamp": timestamp,
+        "message": message,
+        "level": level,
+    }
+
+func _parse_success_entry(message: String, timestamp: String) -> Dictionary:
+    var payload_split := message.find(" with payload ")
+    if payload_split == -1:
+        payload_split = message.length()
+    var signal_name := message.substr("Replayed ".length, payload_split - "Replayed ".length)
+    return {
+        "type": "eventbus_replay_entry",
+        "timestamp": timestamp,
+        "signal_name": signal_name,
+        "status": "ok",
+        "message": message,
+    }
+
+func _parse_failure_entry(message: String, timestamp: String) -> Dictionary:
+    var payload_split := message.find(" with payload ")
+    if payload_split == -1:
+        payload_split = message.length()
+    var signal_name := message.substr("Failed to replay ".length, payload_split - "Failed to replay ".length)
+    return {
+        "type": "eventbus_replay_entry",
+        "timestamp": timestamp,
+        "signal_name": signal_name,
+        "status": "error",
+        "message": message,
+    }
+
+func _parse_skipped_entry(message: String, timestamp: String) -> Dictionary:
+    var parts := message.split(" ")
+    var index_text := parts.size() >= 3 ? parts[2] : "0"
+    var entry_index := index_text.to_int()
+    return {
+        "type": "eventbus_replay_entry",
+        "timestamp": timestamp,
+        "signal_name": "",
+        "status": "skipped",
+        "message": message,
+        "entry_index": entry_index,
+    }
+
+func _print_usage() -> void:
+    print("Usage: godot --headless --script res://tests/eventbus_replay_runner.gd <replay.json> [--export-log <path>] [--echo-log]")
+
+func _emit_json(payload: Dictionary) -> void:
+    print(JSON.stringify(payload))

--- a/tools/codex_replay_eventbus.py
+++ b/tools/codex_replay_eventbus.py
@@ -1,0 +1,205 @@
+"""Codex helpers for replaying EventBus transcripts headlessly.
+
+This module builds on :mod:`tools.codex_godot_process_manager` to launch the
+``eventbus_replay_runner.gd`` SceneTree script, stream the structured JSON
+messages it emits, and aggregate a machine-readable report that outside
+engineers can consume.  The helper mirrors the behaviour that Codex uses in CI
+so manual operators can diagnose issues locally with the same tooling.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+from .codex_godot_process_manager import CodexGodotProcessManager
+
+DEFAULT_REPLAY_SCRIPT = "res://tests/eventbus_replay_runner.gd"
+
+
+@dataclass
+class ReplayEntry:
+    """Represents a single replay attempt emitted by the harness."""
+
+    index: int
+    signal_name: str
+    status: str
+    message: str
+    timestamp: Optional[str] = None
+
+
+@dataclass
+class ReplayReport:
+    """Aggregated report describing the outcome of a replay run."""
+
+    entries: List[ReplayEntry] = field(default_factory=list)
+    summary: Dict[str, object] = field(default_factory=dict)
+    diagnostics: List[Dict[str, object]] = field(default_factory=list)
+    logs: List[Dict[str, object]] = field(default_factory=list)
+    log_export_path: Optional[str] = None
+    echoed_log: Optional[str] = None
+
+    @property
+    def success(self) -> bool:
+        """Return ``True`` when the harness reported a clean replay."""
+
+        exit_code = int(self.summary.get("exit_code", 1))
+        return exit_code == 0
+
+
+def replay_eventbus_transcript(
+    replay_path: Path | str,
+    *,
+    export_log_path: Path | str | None = None,
+    echo_log: bool = False,
+    extra_godot_args: Optional[Sequence[str]] = None,
+    manager_kwargs: Optional[Dict[str, object]] = None,
+    replay_script: str = DEFAULT_REPLAY_SCRIPT,
+) -> ReplayReport:
+    """Run the EventBus replay harness and return a structured report.
+
+    Parameters
+    ----------
+    replay_path:
+        Filesystem path to the JSON transcript that should be replayed.
+    export_log_path:
+        Optional path where the harness log should be exported on success.
+    echo_log:
+        When ``True`` the harness echoes its RichText transcript through the
+        JSON stream so it can be surfaced in terminal output.
+    extra_godot_args:
+        Additional command line arguments forwarded to Godot *before* the
+        ``-s`` flag.  Use this sparingly – the helper automatically injects the
+        replay runner path and transcript parameters.
+    manager_kwargs:
+        Optional keyword arguments forwarded to
+        :class:`CodexGodotProcessManager`.  ``extra_args`` should not be
+        provided here; use :paramref:`extra_godot_args` instead.
+    replay_script:
+        Override the path to the replay runner script.  Defaults to
+        :data:`DEFAULT_REPLAY_SCRIPT`.
+    """
+
+    transcript = Path(replay_path)
+    if not transcript.exists():
+        raise FileNotFoundError(f"Replay transcript not found: {transcript}")
+
+    command: List[str] = list(extra_godot_args or [])
+    command.extend(["-s", replay_script, str(transcript)])
+    if export_log_path is not None:
+        command.extend(["--export-log", str(export_log_path)])
+    if echo_log:
+        command.append("--echo-log")
+
+    manager_config = dict(manager_kwargs or {})
+    if "extra_args" in manager_config:
+        raise ValueError(
+            "Pass extra Godot CLI arguments via extra_godot_args instead of manager_kwargs['extra_args']."
+        )
+
+    report = ReplayReport()
+    with CodexGodotProcessManager(extra_args=command, **manager_config) as manager:
+        message_iterator = manager.iter_messages(timeout=0.1)
+        while True:
+            try:
+                message = next(message_iterator)
+            except StopIteration:
+                break
+
+            message_type = message.get("type")
+            if message_type == "eventbus_replay_entry":
+                report.entries.append(
+                    ReplayEntry(
+                        index=int(message.get("index", 0)),
+                        signal_name=str(message.get("signal_name", "")),
+                        status=str(message.get("status", "")),
+                        message=str(message.get("message", "")),
+                        timestamp=message.get("timestamp"),
+                    )
+                )
+            elif message_type == "eventbus_replay_summary":
+                report.summary = message
+                break
+            elif message_type == "eventbus_replay_log_export":
+                report.log_export_path = str(message.get("path"))
+            elif message_type == "eventbus_replay_log":
+                report.logs.append(message)
+            elif message_type == "eventbus_replay_echo":
+                report.echoed_log = str(message.get("text", ""))
+            elif message_type == "eventbus_replay_error":
+                report.summary = message
+                break
+            else:
+                report.diagnostics.append(message)
+
+        report.diagnostics.extend(list(manager.iter_stderr_diagnostics()))
+
+    return report
+
+
+def format_report(report: ReplayReport) -> str:
+    """Render a human readable summary for terminal output."""
+
+    lines = []
+    lines.append("EventBus Replay Summary")
+    lines.append("=======================")
+    lines.append(
+        f"Status: {'OK' if report.success else 'FAILED'} | "
+        f"Entries: {report.summary.get('total', len(report.entries))} | "
+        f"Succeeded: {report.summary.get('succeeded', 0)} | "
+        f"Failed: {report.summary.get('failed', 0)} | "
+        f"Skipped: {report.summary.get('skipped', 0)}"
+    )
+    if report.log_export_path:
+        lines.append(f"Log exported to: {report.log_export_path}")
+    if report.echoed_log:
+        lines.append("\nHarness Log:")
+        lines.append(report.echoed_log)
+    if report.entries:
+        lines.append("\nEntries:")
+        for entry in report.entries:
+            lines.append(
+                f"  [{entry.index:02d}] {entry.signal_name or 'n/a'} -> {entry.status.upper()} | {entry.message}"
+            )
+    if report.logs:
+        lines.append("\nHarness Messages:")
+        for log in report.logs:
+            lines.append(json.dumps(log, sort_keys=True))
+    if report.diagnostics:
+        lines.append("\nDiagnostics:")
+        for diagnostic in report.diagnostics:
+            lines.append(json.dumps(diagnostic, sort_keys=True))
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ReplayEntry",
+    "ReplayReport",
+    "replay_eventbus_transcript",
+    "format_report",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience CLI
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Replay EventBus transcripts headlessly via Codex.")
+    parser.add_argument("replay", type=Path, help="Path to the replay JSON file.")
+    parser.add_argument("--export-log", dest="export_log", type=Path, help="Optional path to export the harness log.")
+    parser.add_argument(
+        "--echo-log",
+        dest="echo_log",
+        action="store_true",
+        help="Echo the harness log back to stdout after the replay completes.",
+    )
+    args = parser.parse_args()
+
+    report = replay_eventbus_transcript(
+        args.replay,
+        export_log_path=args.export_log,
+        echo_log=args.echo_log,
+    )
+    print(format_report(report))
+    raise SystemExit(0 if report.success else 1)


### PR DESCRIPTION
## Summary
- add a headless EventBus replay runner that validates transcripts, streams JSON outcomes, and supports optional log export/echo flags
- expose a Python helper that drives the runner via CodexGodotProcessManager and aggregates a structured replay report
- document Codex' EventBus troubleshooting workflow and expected replay JSON schema for manual operators

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cba3c010108320ac335a67c5ad07c8