### PR TITLE
Add inventory and faction components

### DIFF
--- a/src/components/FactionComponent.gd
+++ b/src/components/FactionComponent.gd
@@ -1,0 +1,23 @@
+extends "res://src/core/Component.gd"
+class_name FactionComponent
+
+## Foundational social alignment record for entities participating in the simulation. The
+## AI targeting logic, quest planners, and narrative systems inspect this data to
+## determine alliances, hostilities, and situational loyalties. Designers can assign
+## faction identifiers directly in the Inspector while tooling scripts synchronise
+## reputation values against a master faction matrix.
+##
+## Designed for Godot 4.4.1.
+
+@export_group("Faction Identity")
+## String identifier representing the entity's primary faction membership. Standard practice
+## is to use lowercase snake_case tokens that align with campaign documentation (e.g.,
+## "free_merchants", "shadow_syndicate"). Systems must treat an empty string as "unaligned".
+@export var faction_id: String = ""
+
+@export_group("Reputation Matrix")
+## Dictionary storing reputation deltas toward other factions. Keys must be faction string
+## identifiers while values represent integer reputation scores. Positive numbers indicate
+## friendly standing, zero represents neutrality, and negative numbers denote hostility. The
+## QuestPlanner and AI targeting filters will treat missing keys as neutral relationships.
+@export var reputation: Dictionary[String, int] = {}

--- a/src/components/InventoryComponent.gd
+++ b/src/components/InventoryComponent.gd
@@ -1,0 +1,18 @@
+extends "res://src/core/Component.gd"
+class_name InventoryComponent
+
+## Canonical inventory manifest describing every physical object currently associated with
+## an entity. This resource acts as the shared data contract between the LootSystem,
+## UISystem, and future crafting or trade interfaces. It intentionally remains lightweight
+## until the dedicated ``Item`` resource ships, at which point the ``items`` array will
+## contain strongly typed references instead of arbitrary data dictionaries.
+##
+## Designed for Godot 4.4.1.
+
+@export_group("Inventory")
+## Ordered list of item descriptors owned by the entity. Systems consuming this component
+## should duplicate the array prior to mutation to avoid coupling editor state to runtime
+## logic. Entries are currently untyped to maximise prototyping velocity; downstream
+## systems should treat each element as either a lightweight identifier (StringName) or a
+## Dictionary describing stack counts and metadata until the item framework stabilises.
+@export var items: Array = []


### PR DESCRIPTION
## Summary
- add an InventoryComponent resource that exposes exported item entries for loot, UI, and trading systems
- add a FactionComponent resource that stores faction identity and reputation relationships for AI and quest planners

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'gdscript_parse_helper')*

------
https://chatgpt.com/codex/tasks/task_e_68cc4bd3696c8320b685efba508e1b2b