### PR TITLE
Handle corrupted Codex manifest results

### DIFF
--- a/tools/CodexAutomation.md
+++ b/tools/CodexAutomation.md
@@ -155,6 +155,14 @@ command line for executing the entire manifest suite in the same way Codex does
 during automated reviews.  Outside engineers can use it to reproduce failures
 locally, capture diagnostics, or experiment with new test manifests.
 
+When the Godot runner emits a corrupted or truncated `tests/results.json`, the
+helper now catches the JSON parsing error and returns a `ManifestSummary` with
+an explanatory message instead of raising an exception.  Both the terminal
+summary and the structured Codex payload include the `error` field so outside
+engineers and Codex operators can immediately see that the report itself was
+malformed.  This ensures automation surfaces actionable diagnostics without
+masking the underlying run status.
+
 ## Preflight orchestration with Codex
 
 Codex now exposes a single entry point for end-to-end validation via

--- a/tools/codex_run_manifest_tests.py
+++ b/tools/codex_run_manifest_tests.py
@@ -287,7 +287,15 @@ def _load_json_results(path: Path) -> tuple[ManifestSummary, List[ScriptReport]]
     if not path.exists():
         return ManifestSummary(error=f"JSON results missing at {path}"), []
 
-    data = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return (
+            ManifestSummary(
+                error=f"Failed to parse JSON results at {path}: {exc}"
+            ),
+            [],
+        )
     summary_data = data.get("summary", {}) if isinstance(data, dict) else {}
     tests_data = data.get("tests", []) if isinstance(data, dict) else []
 

--- a/tools/python_tests/test_codex_run_manifest_tests.py
+++ b/tools/python_tests/test_codex_run_manifest_tests.py
@@ -52,3 +52,47 @@ def test_run_godot_uses_public_wait(monkeypatch):
     manager = created[0]
     assert manager.kwargs["godot_binary"] == "/godot"
     assert manager.kwargs["project_root"] == "/project"
+
+
+def test_load_json_results_handles_corrupted_json(tmp_path):
+    results_path = tmp_path / "results.json"
+    results_path.write_text("{not-valid", encoding="utf-8")
+
+    summary, scripts = codex_run_manifest_tests._load_json_results(results_path)
+
+    assert summary.scripts_passed == 0
+    assert summary.scripts_failed == 0
+    assert summary.assertions == 0
+    assert summary.error is not None
+    assert "Failed to parse JSON results" in summary.error
+    assert scripts == []
+
+
+def test_execute_attempt_surfaces_corrupted_json(monkeypatch, tmp_path):
+    json_path = tmp_path / "results.json"
+    json_path.write_text("{broken", encoding="utf-8")
+
+    xml_path = tmp_path / "results.xml"
+    manifest_path = tmp_path / "tests_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+
+    def fake_run_godot(*, project_root, godot_binary, extra_env=None):
+        return 1, [], 0.1
+
+    monkeypatch.setattr(codex_run_manifest_tests, "_run_godot", fake_run_godot)
+
+    run = codex_run_manifest_tests._execute_attempt(
+        attempt=1,
+        max_attempts=1,
+        project_root=tmp_path,
+        godot_binary=tmp_path / "godot",
+        manifest_path=manifest_path,
+        json_path=json_path,
+        xml_path=xml_path,
+        cleanup=False,
+    )
+
+    assert run.summary.error is not None
+    assert "Failed to parse JSON results" in run.summary.error
+    assert run.scripts == []
+    assert run.exit_code == 1


### PR DESCRIPTION
## Summary
- wrap manifest JSON parsing in `codex_run_manifest_tests` with error handling so corrupted reports surface a structured failure
- add regression tests covering corrupted JSON both at the loader and during an execution attempt
- document the new diagnostics surfaced to Codex operators when `tests/results.json` is malformed

## Testing
- `python -m pytest tools/python_tests`


------
https://chatgpt.com/codex/tasks/task_e_68cc7de973b483208f0507e6ac7f9c2e