### PR TITLE
Fix EntityData component manifest typing for editor usability

### DIFF
--- a/src/tests/TestStatsComponent.gd
+++ b/src/tests/TestStatsComponent.gd
@@ -195,6 +195,7 @@ func run_test() -> Dictionary:
         "lore",
         "technical",
         "advanced_training",
+        "skill_catalog",
         "skill_levels",
         "skill_options",
         "equipped_items",


### PR DESCRIPTION
## Summary
- type the EntityData `components` export as `Dictionary[StringName, Component]` while keeping the internal manifest sanitized for valid component resources
- refresh the stats component regression test to expect the `skill_catalog` entry returned by defensive snapshots

## Testing
- godot4 --headless --path . --script res://tests/run_all_tests.gd

------
https://chatgpt.com/codex/tasks/task_e_68cc8937d3388320a949f5b19d3eb597