### PR TITLE
Fix System Testbed panel wiring for unique-node lookups

### DIFF
--- a/tests/scenes/System_Testbed.tscn
+++ b/tests/scenes/System_Testbed.tscn
@@ -66,13 +66,16 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="ArchetypeSelector" type="OptionButton" parent="RootPanel/MainHBox/LeftColumn/EntitySpawnerPanel/EntitySpawnerContent/EntitySpawnerScroll/EntitySpawnerBody"]
+unique_name_in_owner = true
 size_flags_horizontal = 3
 
 [node name="SpawnButton" type="Button" parent="RootPanel/MainHBox/LeftColumn/EntitySpawnerPanel/EntitySpawnerContent/EntitySpawnerScroll/EntitySpawnerBody"]
+unique_name_in_owner = true
 text = "Spawn Entity"
 size_flags_horizontal = 3
 
 [node name="SpawnStatusLabel" type="Label" parent="RootPanel/MainHBox/LeftColumn/EntitySpawnerPanel/EntitySpawnerContent/EntitySpawnerScroll/EntitySpawnerBody"]
+unique_name_in_owner = true
 text = "Loading archetypes..."
 autowrap_mode = 3
 
@@ -100,12 +103,14 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="SceneInspectorTree" type="Tree" parent="RootPanel/MainHBox/LeftColumn/SceneInspectorPanel/SceneInspectorContent/SceneInspectorScroll/SceneInspectorBody"]
+unique_name_in_owner = true
 visible = false
 size_flags_horizontal = 3
 size_flags_vertical = 3
 hide_root = true
 
 [node name="SceneInspectorPlaceholder" type="Label" parent="RootPanel/MainHBox/LeftColumn/SceneInspectorPanel/SceneInspectorContent/SceneInspectorScroll/SceneInspectorBody"]
+unique_name_in_owner = true
 text = "Inspect the live scene graph here."
 autowrap_mode = 3
 

--- a/tests/scripts/system_testbed/EntitySpawnerPanel.gd
+++ b/tests/scripts/system_testbed/EntitySpawnerPanel.gd
@@ -5,8 +5,8 @@ class_name EntitySpawnerPanel
 const ENTITY_DIRECTORY := "res://assets/entity_archetypes/"
 const ENTITY_SCENE_PATH := "res://src/entities/Entity.tscn"
 
-const EntityData := preload("res://src/core/EntityData.gd")
-const Entity := preload("res://src/entities/Entity.gd")
+const ENTITY_DATA_SCRIPT := preload("res://src/core/EntityData.gd")
+const ENTITY_SCRIPT := preload("res://src/entities/Entity.gd")
 
 @onready var _archetype_selector: OptionButton = %ArchetypeSelector
 @onready var _spawn_button: Button = %SpawnButton
@@ -85,7 +85,7 @@ func _on_spawn_button_pressed() -> void:
     if base_resource == null:
         _update_status("Unable to locate resource for %s." % archetype_id)
         return
-    if not (base_resource is EntityData):
+    if not (base_resource is ENTITY_DATA_SCRIPT):
         _update_status("%s is not an EntityData resource." % archetype_id)
         return
 
@@ -96,7 +96,7 @@ func _on_spawn_button_pressed() -> void:
         return
 
     var entity_instance := entity_scene.instantiate()
-    if not (entity_instance is Entity):
+    if not (entity_instance is ENTITY_SCRIPT):
         if entity_instance != null:
             entity_instance.queue_free()
         _update_status("Base entity scene does not provide the Entity script.")

--- a/tests/scripts/system_testbed/SceneInspectorPanel.gd
+++ b/tests/scripts/system_testbed/SceneInspectorPanel.gd
@@ -2,16 +2,17 @@ extends PanelContainer
 class_name SceneInspectorPanel
 """Displays and manages live entities spawned into the System Testbed."""
 
-const Entity := preload("res://src/entities/Entity.gd")
+const ENTITY_SCRIPT := preload("res://src/entities/Entity.gd")
+const SYSTEM_TESTBED_SCRIPT := preload("res://tests/scripts/system_testbed/SystemTestbed.gd")
 
 @onready var _tree: Tree = %SceneInspectorTree
 @onready var _placeholder_label: Label = %SceneInspectorPlaceholder
 
 var _test_environment: Node
-var _testbed_root: SystemTestbed
+var _testbed_root: SYSTEM_TESTBED_SCRIPT
 var _tree_root: TreeItem
 var _entity_items: Dictionary = {}
-var _current_selection: Entity
+var _current_selection: ENTITY_SCRIPT
 
 func _ready() -> void:
     """Wires selection hooks and seeds the inspector with current entities."""
@@ -35,7 +36,7 @@ func _resolve_test_environment() -> Node:
     var current_scene := get_tree().get_current_scene()
     if current_scene == null:
         return null
-    _testbed_root = current_scene as SystemTestbed
+    _testbed_root = current_scene as SYSTEM_TESTBED_SCRIPT
     _test_environment = current_scene.get_node_or_null("TestEnvironment")
     return _test_environment
 
@@ -65,7 +66,7 @@ func _track_entity(node: Node) -> void:
     if not _is_entity(node):
         return
 
-    var entity := node as Entity
+    var entity := node as ENTITY_SCRIPT
     var key := entity.get_instance_id()
     if _entity_items.has(key):
         return
@@ -82,7 +83,7 @@ func _untrack_entity(node: Node) -> void:
     if not _is_entity(node):
         return
 
-    var entity := node as Entity
+    var entity := node as ENTITY_SCRIPT
     var key := entity.get_instance_id()
     if _entity_items.has(key):
         var item: TreeItem = _entity_items[key]
@@ -110,7 +111,7 @@ func _on_tree_item_selected() -> void:
     var item := _tree.get_selected()
     if item == null:
         return
-    var entity := item.get_metadata(0) as Entity
+    var entity := item.get_metadata(0) as ENTITY_SCRIPT
     if not is_instance_valid(entity):
         _tree.deselect_all()
         _set_active_target(null)
@@ -123,11 +124,11 @@ func _on_tree_nothing_selected() -> void:
     _current_selection = null
     _set_active_target(null)
 
-func _set_active_target(target: Entity) -> void:
+func _set_active_target(target: ENTITY_SCRIPT) -> void:
     """Pushes the selection to the testbed root for other panels to consume."""
     if _testbed_root == null or not is_instance_valid(_testbed_root):
         var current_scene := get_tree().get_current_scene()
-        _testbed_root = current_scene as SystemTestbed
+        _testbed_root = current_scene as SYSTEM_TESTBED_SCRIPT
     if _testbed_root != null:
         _testbed_root.active_target_entity = target
 
@@ -149,9 +150,9 @@ func _ensure_tree_root() -> TreeItem:
 
 func _is_entity(node: Node) -> bool:
     """Validates that a node is an Entity instance with display metadata."""
-    return node is Entity
+    return node is ENTITY_SCRIPT
 
-func _format_entity_label(entity: Entity) -> String:
+func _format_entity_label(entity: ENTITY_SCRIPT) -> String:
     """Builds the label text presented in the inspector tree."""
     if entity == null:
         return "Unknown Entity"


### PR DESCRIPTION
## Summary
- mark the System Testbed UI controls with unique owner names so onready lookups succeed when the scene instantiates
- preload the SystemTestbed and Entity scripts under descriptive constants to avoid class-name shadow warnings and keep type hints intact
- update the inspector logic to rely on the preloaded script types for casting and active target tracking

## Testing
- godot4 --headless --path . --scene res://tests/scenes/System_Testbed.tscn --quit
- python tools/gdscript_parse_helper.py tests/scripts/system_testbed
- godot4 --headless --path . --script res://tests/run_all_tests.gd

------
https://chatgpt.com/codex/tasks/task_e_68ceb4ac821483208565d894a5f83d15