### PR TITLE
Implement combat triggers and event bus logging in testbed

### DIFF
--- a/tests/scenes/System_Testbed.tscn
+++ b/tests/scenes/System_Testbed.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3]
+[gd_scene load_steps=8 format=3]
 
 [ext_resource type="Script" path="res://tests/scripts/system_testbed/EntitySpawnerPanel.gd" id="1"]
 [ext_resource type="Script" path="res://tests/scripts/system_testbed/SceneInspectorPanel.gd" id="2"]
@@ -6,6 +6,7 @@
 [ext_resource type="Script" path="res://tests/scripts/system_testbed/SystemTriggerPanel.gd" id="4"]
 [ext_resource type="Script" path="res://tests/scripts/system_testbed/EventBusLogPanel.gd" id="5"]
 [ext_resource type="Script" path="res://tests/scripts/system_testbed/SystemTestbed.gd" id="6"]
+[ext_resource type="Script" path="res://tests/scripts/system_testbed/Test_CombatSystem.gd" id="7"]
 
 [node name="System_Testbed" type="Control"]
 anchors_preset = 15
@@ -25,6 +26,10 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="TestEnvironment" type="Node" parent="."]
+
+[node name="TestCombatSystem" type="Node" parent="."]
+unique_name_in_owner = true
+script = ExtResource("7")
 
 [node name="MainHBox" type="HBoxContainer" parent="RootPanel"]
 anchors_preset = 15
@@ -177,6 +182,26 @@ scroll_horizontal = false
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
+[node name="SystemTriggerActions" type="VBoxContainer" parent="RootPanel/MainHBox/RightColumn/SystemTriggerPanel/SystemTriggerContent/SystemTriggerScroll/SystemTriggerBody"]
+unique_name_in_owner = true
+size_flags_horizontal = 3
+theme_override_constants/separation = 6
+
+[node name="ApplyFireDamageButton" type="Button" parent="RootPanel/MainHBox/RightColumn/SystemTriggerPanel/SystemTriggerContent/SystemTriggerScroll/SystemTriggerBody/SystemTriggerActions"]
+unique_name_in_owner = true
+text = "Apply 10 Fire Damage to Target"
+size_flags_horizontal = 3
+
+[node name="KillTargetButton" type="Button" parent="RootPanel/MainHBox/RightColumn/SystemTriggerPanel/SystemTriggerContent/SystemTriggerScroll/SystemTriggerBody/SystemTriggerActions"]
+unique_name_in_owner = true
+text = "Kill Target"
+size_flags_horizontal = 3
+
+[node name="EmitEntityKilledButton" type="Button" parent="RootPanel/MainHBox/RightColumn/SystemTriggerPanel/SystemTriggerContent/SystemTriggerScroll/SystemTriggerBody/SystemTriggerActions"]
+unique_name_in_owner = true
+text = "Emit 'entity_killed' Signal"
+size_flags_horizontal = 3
+
 [node name="SystemTriggerPlaceholder" type="Label" parent="RootPanel/MainHBox/RightColumn/SystemTriggerPanel/SystemTriggerContent/SystemTriggerScroll/SystemTriggerBody"]
 text = "Trigger gameplay systems from this panel."
 autowrap_mode = 3
@@ -203,6 +228,13 @@ scroll_horizontal = false
 [node name="EventBusLogBody" type="VBoxContainer" parent="RootPanel/MainHBox/RightColumn/EventBusLogPanel/EventBusLogContent/EventBusLogScroll"]
 size_flags_horizontal = 3
 size_flags_vertical = 3
+
+[node name="EventBusLogOutput" type="RichTextLabel" parent="RootPanel/MainHBox/RightColumn/EventBusLogPanel/EventBusLogContent/EventBusLogScroll/EventBusLogBody"]
+unique_name_in_owner = true
+size_flags_horizontal = 3
+size_flags_vertical = 3
+scroll_active = true
+selection_enabled = true
 
 [node name="EventBusLogPlaceholder" type="Label" parent="RootPanel/MainHBox/RightColumn/EventBusLogPanel/EventBusLogContent/EventBusLogScroll/EventBusLogBody"]
 text = "Recent EventBus activity will be displayed here."

--- a/tests/scripts/system_testbed/EventBusLogPanel.gd
+++ b/tests/scripts/system_testbed/EventBusLogPanel.gd
@@ -5,6 +5,72 @@ Streams recent EventBus activity so operators can validate system interactions i
 At present the panel is a scaffold that will later subscribe to debug log feeds.
 """
 
+const EVENT_BUS_SCRIPT := preload("res://src/globals/EventBus.gd")
+
+@onready var _placeholder_label: Label = %EventBusLogPlaceholder
+@onready var _log_output: RichTextLabel = %EventBusLogOutput
+
+var _connected_signals: Array[StringName] = []
+var _entry_count := 0
+
 func _ready() -> void:
-    """Connects log display widgets once they are implemented."""
-    pass
+    """Connects to every EventBus signal and prepares the log display."""
+    _initialise_log_output()
+    _connect_event_bus_signals()
+    _update_placeholder_visibility()
+
+func _initialise_log_output() -> void:
+    """Clears any stale content from the log label before use."""
+    if is_instance_valid(_log_output):
+        _log_output.clear()
+
+func _connect_event_bus_signals() -> void:
+    """Iterates through the EventBus signal catalog and hooks the generic handler."""
+    var event_bus := _resolve_event_bus()
+    if event_bus == null:
+        push_warning("EventBus singleton is unavailable; log will remain empty.")
+        return
+
+    for signal_data in event_bus.get_signal_list():
+        var signal_name := StringName(signal_data.get("name", ""))
+        if signal_name == StringName():
+            continue
+        var callable := Callable(self, "_on_event_bus_signal").bind(signal_name)
+        if event_bus.is_connected(signal_name, callable):
+            continue
+        var error_code := event_bus.connect(signal_name, callable)
+        if error_code != OK:
+            push_warning("Failed to connect to EventBus signal %s (error %d)." % [signal_name, error_code])
+            continue
+        _connected_signals.append(signal_name)
+
+func _resolve_event_bus() -> EVENT_BUS_SCRIPT:
+    """Returns the active EventBus singleton when registered as an autoload."""
+    if not EVENT_BUS_SCRIPT.is_singleton_ready():
+        return null
+    return EVENT_BUS_SCRIPT.get_singleton()
+
+func _on_event_bus_signal(payload: Variant, signal_name: StringName) -> void:
+    """Generic handler that formats signal payloads into the log feed."""
+    var payload_string := _format_payload(payload)
+    var entry := "[b]%s[/b]: %s" % [signal_name, payload_string]
+    if is_instance_valid(_log_output):
+        _log_output.append_text(entry + "\n")
+        _log_output.scroll_to_line(_log_output.get_line_count() - 1)
+    _entry_count += 1
+    _update_placeholder_visibility()
+
+func _format_payload(payload: Variant) -> String:
+    """Produces a readable representation of the payload for the log."""
+    if typeof(payload) == TYPE_DICTIONARY:
+        var json := JSON.new()
+        return json.stringify(payload, "  ")
+    return str(payload)
+
+func _update_placeholder_visibility() -> void:
+    """Toggles the placeholder text based on whether any log entries exist."""
+    var has_entries := _entry_count > 0
+    if is_instance_valid(_log_output):
+        _log_output.visible = has_entries
+    if is_instance_valid(_placeholder_label):
+        _placeholder_label.visible = not has_entries

--- a/tests/scripts/system_testbed/SystemTriggerPanel.gd
+++ b/tests/scripts/system_testbed/SystemTriggerPanel.gd
@@ -5,6 +5,133 @@ Hosts manual triggers for gameplay systems so engineers can exercise signal flow
 Future milestones will expose buttons, dropdowns, and parameter editors to drive systems.
 """
 
+const SYSTEM_TESTBED_SCRIPT := preload("res://tests/scripts/system_testbed/SystemTestbed.gd")
+const TEST_COMBAT_SYSTEM_SCRIPT := preload("res://tests/scripts/system_testbed/Test_CombatSystem.gd")
+const EVENT_BUS_SCRIPT := preload("res://src/globals/EventBus.gd")
+
+@onready var _placeholder_label: Label = %SystemTriggerPlaceholder
+@onready var _actions_container: VBoxContainer = %SystemTriggerActions
+@onready var _apply_damage_button: Button = %ApplyFireDamageButton
+@onready var _kill_target_button: Button = %KillTargetButton
+@onready var _emit_entity_killed_button: Button = %EmitEntityKilledButton
+@onready var _combat_system: TEST_COMBAT_SYSTEM_SCRIPT = %TestCombatSystem
+
+var _testbed_root: SYSTEM_TESTBED_SCRIPT
+
 func _ready() -> void:
-    """Placeholder for wiring trigger buttons to the EventBus."""
-    pass
+    """Wires trigger buttons so operators can exercise combat and bus interactions."""
+    _testbed_root = _resolve_testbed_root()
+    _wire_buttons()
+    _subscribe_to_target_updates()
+    _update_button_states()
+    _update_placeholder_visibility()
+
+func _wire_buttons() -> void:
+    """Safely connects UI button presses to their handlers."""
+    if is_instance_valid(_apply_damage_button):
+        _apply_damage_button.pressed.connect(_on_apply_damage_pressed)
+    else:
+        push_warning("SystemTriggerPanel missing ApplyFireDamageButton; damage trigger disabled.")
+
+    if is_instance_valid(_kill_target_button):
+        _kill_target_button.pressed.connect(_on_kill_target_pressed)
+    else:
+        push_warning("SystemTriggerPanel missing KillTargetButton; kill trigger disabled.")
+
+    if is_instance_valid(_emit_entity_killed_button):
+        _emit_entity_killed_button.pressed.connect(_on_emit_entity_killed_pressed)
+    else:
+        push_warning("SystemTriggerPanel missing EmitEntityKilledButton; manual signal trigger disabled.")
+
+func _subscribe_to_target_updates() -> void:
+    """Listens for active target changes so button state mirrors selection availability."""
+    var testbed := _resolve_testbed_root()
+    if testbed == null:
+        push_warning("SystemTriggerPanel could not resolve SystemTestbed root; target-aware triggers disabled.")
+        return
+    if not testbed.active_target_entity_changed.is_connected(_on_active_target_entity_changed):
+        testbed.active_target_entity_changed.connect(_on_active_target_entity_changed)
+
+func _resolve_testbed_root() -> SYSTEM_TESTBED_SCRIPT:
+    """Caches the SystemTestbed instance that tracks the active entity selection."""
+    if is_instance_valid(_testbed_root):
+        return _testbed_root
+    var current_scene := get_tree().get_current_scene()
+    _testbed_root = current_scene as SYSTEM_TESTBED_SCRIPT
+    return _testbed_root
+
+func _get_active_target() -> Node:
+    """Retrieves the currently selected entity from the SystemTestbed."""
+    var testbed := _resolve_testbed_root()
+    if testbed == null:
+        return null
+    return testbed.active_target_entity
+
+func _on_apply_damage_pressed() -> void:
+    """Invokes the temporary combat system to simulate a fire damage event."""
+    var target := _get_active_target()
+    if target == null:
+        push_warning("Select an entity in the Scene Inspector before applying damage.")
+        return
+    if not is_instance_valid(_combat_system):
+        push_warning("Test_CombatSystem node is unavailable; cannot apply damage.")
+        return
+    if not _combat_system.has_method("apply_damage"):
+        push_warning("Test_CombatSystem is missing apply_damage(); trigger skipped.")
+        return
+    _combat_system.apply_damage(target, 10, "fire")
+
+func _on_kill_target_pressed() -> void:
+    """Invokes the temporary combat system to simulate a kill."""
+    var target := _get_active_target()
+    if target == null:
+        push_warning("Select an entity in the Scene Inspector before triggering a kill.")
+        return
+    if not is_instance_valid(_combat_system):
+        push_warning("Test_CombatSystem node is unavailable; cannot kill target.")
+        return
+    if not _combat_system.has_method("kill_target"):
+        push_warning("Test_CombatSystem is missing kill_target(); trigger skipped.")
+        return
+    _combat_system.kill_target(target)
+
+func _on_emit_entity_killed_pressed() -> void:
+    """Manually emits the entity_killed signal on the EventBus for logging validation."""
+    var event_bus := _resolve_event_bus()
+    if event_bus == null:
+        push_warning("EventBus singleton not available; cannot emit entity_killed signal.")
+        return
+    var payload := {
+        "entity_id": "debug_entity_id",
+        "killer_id": "system_trigger_panel",
+        "archetype_id": "DebugGoblin_EntityData.tres",
+    }
+    var error_code := event_bus.emit_signal(&"entity_killed", payload)
+    if error_code != OK:
+        push_warning("Failed to emit entity_killed signal; error code %d." % error_code)
+
+func _resolve_event_bus() -> EVENT_BUS_SCRIPT:
+    """Returns the active EventBus singleton when registered as an autoload."""
+    if not EVENT_BUS_SCRIPT.is_singleton_ready():
+        return null
+    return EVENT_BUS_SCRIPT.get_singleton()
+
+func _on_active_target_entity_changed(_target: Node) -> void:
+    """Recomputes button enabled state whenever the selection updates."""
+    _update_button_states()
+
+func _update_button_states() -> void:
+    """Enables target-dependent triggers only when a selection exists."""
+    var has_target := is_instance_valid(_get_active_target())
+    if is_instance_valid(_apply_damage_button):
+        _apply_damage_button.disabled = not has_target
+    if is_instance_valid(_kill_target_button):
+        _kill_target_button.disabled = not has_target
+
+func _update_placeholder_visibility() -> void:
+    """Hides the placeholder label whenever actionable controls are present."""
+    var has_actions := is_instance_valid(_actions_container) and _actions_container.get_child_count() > 0
+    if is_instance_valid(_actions_container):
+        _actions_container.visible = has_actions
+    if is_instance_valid(_placeholder_label):
+        _placeholder_label.visible = not has_actions

--- a/tests/scripts/system_testbed/Test_CombatSystem.gd
+++ b/tests/scripts/system_testbed/Test_CombatSystem.gd
@@ -1,0 +1,17 @@
+extends Node
+class_name Test_CombatSystem
+"""Temporary combat harness used to validate SystemTriggerPanel interactions."""
+
+func apply_damage(target: Node, amount: int, damage_type: String) -> void:
+    """Logs a debug message when damage is applied to confirm wiring works."""
+    var target_name := "[null]"
+    if is_instance_valid(target):
+        target_name = "%s (%s)" % [target.name, target.get_path()]
+    print("[Test_CombatSystem] apply_damage -> target=%s, amount=%d, type=%s" % [target_name, amount, damage_type])
+
+func kill_target(target: Node) -> void:
+    """Logs a debug message when a kill trigger is invoked."""
+    var target_name := "[null]"
+    if is_instance_valid(target):
+        target_name = "%s (%s)" % [target.name, target.get_path()]
+    print("[Test_CombatSystem] kill_target -> target=%s" % target_name)


### PR DESCRIPTION
## Summary
- add temporary Test_CombatSystem node and wire SystemTriggerPanel buttons to apply damage, kill targets, and emit EventBus signals
- implement EventBusLogPanel controller to subscribe to all EventBus signals and append formatted entries to the RichTextLabel
- extend the System_Testbed scene with the new trigger buttons, logging label, and combat harness script for interactive validation

## Testing
- godot4 --headless --path . --quit
- python tools/gdscript_parse_helper.py tests/scripts/system_testbed


------
https://chatgpt.com/codex/tasks/task_e_68cec8dfc6b08320ad4012381e11ad3b