### PR TITLE
Add debug overlay and developer console autoloads

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,8 @@ ULTEnums="*res://src/globals/ULTEnums.gd"
 EventBus="*res://src/globals/EventBus.gd"
 AssetRegistry="*res://src/globals/AssetRegistry.gd"
 ModuleRegistry="*res://src/globals/ModuleRegistry.gd"
+EntityInspectorOverlay="*res://src/debug/entity_inspector/EntityInspectorOverlay.tscn"
+DeveloperConsole="*res://src/debug/developer_console/DeveloperConsole.tscn"
 
 [global]
 

--- a/src/debug/developer_console/DeveloperConsole.gd
+++ b/src/debug/developer_console/DeveloperConsole.gd
@@ -1,0 +1,242 @@
+extends CanvasLayer
+class_name DeveloperConsoleSingleton
+"""Autoloaded dropdown console that executes GDScript expressions at runtime."""
+
+const ENTITY_SCRIPT := preload("res://src/entities/Entity.gd")
+const ENTITY_DATA_SCRIPT := preload("res://src/core/EntityData.gd")
+const ENTITY_SCENE_PATH := "res://src/entities/Entity.tscn"
+
+const DEFAULT_TOGGLE_ACTION := "debug_toggle_console"
+const DEFAULT_HISTORY_LIMIT := 64
+
+@export var toggle_action := DEFAULT_TOGGLE_ACTION
+@export var history_limit := DEFAULT_HISTORY_LIMIT
+
+@onready var _output: RichTextLabel = %ConsoleOutput
+@onready var _input: LineEdit = %ConsoleInput
+
+var _is_active := false
+var _history: Array[String] = []
+var _history_index := -1
+var _command_docs: Dictionary[String, String] = {}
+
+func _ready() -> void:
+    """Initialises the console UI and registers the default command bindings."""
+    visible = false
+    process_mode = Node.PROCESS_MODE_ALWAYS
+    _ensure_input_action(toggle_action, KEY_QUOTELEFT)
+    if is_instance_valid(_input):
+        _input.text_submitted.connect(_on_command_submitted)
+        _input.gui_input.connect(_on_input_gui_event)
+    _register_default_commands()
+    _print_banner()
+
+func _unhandled_input(event: InputEvent) -> void:
+    """Listens for the toggle shortcut so the console can appear above gameplay."""
+    if event.is_action_pressed(toggle_action):
+        _toggle_console()
+        get_viewport().set_input_as_handled()
+
+func _toggle_console() -> void:
+    """Toggles console visibility and focus state."""
+    _is_active = not _is_active
+    visible = _is_active
+    if not is_instance_valid(_input):
+        return
+    if _is_active:
+        _input.grab_focus()
+        _input.caret_column = _input.text.length()
+    else:
+        _input.release_focus()
+        _history_index = _history.size()
+
+func _on_command_submitted(raw_text: String) -> void:
+    """Parses and executes the supplied command string."""
+    var command := raw_text.strip_edges()
+    if command.is_empty():
+        _input.text = ""
+        return
+    _print_prompt(command)
+    _append_history(command)
+    _input.text = ""
+    _execute_command(command)
+
+func _on_input_gui_event(event: InputEvent) -> void:
+    """Handles history navigation keys from the LineEdit control."""
+    if not (event is InputEventKey) or not event.pressed:
+        return
+    var key_event := event as InputEventKey
+    match key_event.keycode:
+        KEY_UP:
+            _step_history(-1)
+            key_event.accept()
+        KEY_DOWN:
+            _step_history(1)
+            key_event.accept()
+
+func _execute_command(command: String) -> void:
+    """Evaluates the console command using Godot's Expression API."""
+    var expression := Expression.new()
+    var parse_error := expression.parse(command)
+    if parse_error != OK:
+        _print_error("Parse", expression.get_error_text())
+        return
+    var result: Variant = expression.execute([], self, true)
+    if expression.has_execute_failed():
+        _print_error("Runtime", expression.get_error_text())
+        return
+    if result != null:
+        _print_line(str(result))
+
+func _append_history(command: String) -> void:
+    """Records executed commands so users can navigate with arrow keys."""
+    if command == "":
+        return
+    if not _history.is_empty() and _history.back() == command:
+        _history_index = _history.size()
+        return
+    _history.append(command)
+    if history_limit > 0 and _history.size() > history_limit:
+        var start: int = max(_history.size() - history_limit, 0)
+        _history = _history.slice(start, _history.size())
+    _history_index = _history.size()
+
+func _step_history(direction: int) -> void:
+    """Moves the history cursor and populates the input line."""
+    if _history.is_empty():
+        return
+    if _history_index < 0 or _history_index > _history.size():
+        _history_index = _history.size()
+    _history_index = clamp(_history_index + direction, 0, _history.size())
+    if _history_index >= _history.size():
+        _input.text = ""
+        _input.caret_column = 0
+        return
+    var entry: String = _history[_history_index]
+    _input.text = entry
+    _input.caret_column = entry.length()
+
+func _print_prompt(command: String) -> void:
+    """Echoes the command back into the transcript with a prompt indicator."""
+    _print_line(":> %s" % command)
+
+func _print_line(text: String) -> void:
+    """Appends a line to the RichTextLabel and scrolls to the latest entry."""
+    if not is_instance_valid(_output):
+        return
+    _output.append_text(text + "\n")
+    _output.scroll_to_line(_output.get_line_count())
+
+func _print_banner() -> void:
+    """Prints the initial console header to orient users."""
+    _print_line("Developer Console ready. Type help() for available commands.")
+
+func _print_error(prefix: String, message: String) -> void:
+    """Formats error messages with emphasis for quick scanning."""
+    _print_line("[color=#ff6b6b]%s error:[/color] %s" % [prefix, message])
+
+func _register_default_commands() -> void:
+    """Registers documentation strings for built-in console helpers."""
+    _command_docs.clear()
+    _command_docs["help"] = "Lists all available console commands."
+    _command_docs["spawn"] = "Spawns the provided EntityData archetype at the player's location."
+
+func help() -> void:
+    """Prints the available console commands and their descriptions."""
+    if _command_docs.is_empty():
+        _print_line("No commands have been registered.")
+        return
+    _print_line("Available commands:")
+    var keys := _command_docs.keys()
+    keys.sort()
+    for command in keys:
+        var description: String = str(_command_docs.get(command, ""))
+        if description == "":
+            _print_line("  %s" % command)
+        else:
+            _print_line("  %s — %s" % [command, description])
+
+func spawn(archetype_id: String) -> Node:
+    """Instantiates an Entity archetype near the player's position."""
+    var trimmed := archetype_id.strip_edges()
+    if trimmed == "":
+        _print_error("Runtime", "Provide an EntityData resource id, e.g. \"GoblinArcher_EntityData.tres\".")
+        return null
+    var registry := AssetRegistry
+    if registry == null:
+        _print_error("Runtime", "AssetRegistry autoload is unavailable.")
+        return null
+    var base_resource := registry.get_asset(trimmed)
+    if base_resource == null:
+        _print_error("Runtime", "Unable to locate asset '%s'." % trimmed)
+        return null
+    if not (base_resource is ENTITY_DATA_SCRIPT):
+        _print_error("Runtime", "Asset '%s' is not an EntityData resource." % trimmed)
+        return null
+    var entity_data: EntityData = base_resource.duplicate(true)
+    var entity_scene: PackedScene = load(ENTITY_SCENE_PATH)
+    if entity_scene == null:
+        _print_error("Runtime", "Base entity scene could not be loaded from %s." % ENTITY_SCENE_PATH)
+        return null
+    var entity_instance := entity_scene.instantiate()
+    if not (entity_instance is ENTITY_SCRIPT):
+        if entity_instance != null:
+            entity_instance.queue_free()
+        _print_error("Runtime", "Base entity scene does not implement the Entity script.")
+        return null
+    entity_instance.entity_data = entity_data
+    if entity_data.display_name != "":
+        entity_instance.name = entity_data.display_name
+    else:
+        entity_instance.name = trimmed.get_basename()
+    var player := _find_player_node()
+    if player == null:
+        entity_instance.queue_free()
+        _print_error("Runtime", "Unable to resolve a Player node to use as a spawn origin.")
+        return null
+    var parent := player.get_parent()
+    if parent == null:
+        parent = get_tree().get_current_scene()
+    if parent == null:
+        entity_instance.queue_free()
+        _print_error("Runtime", "No valid parent found for the spawned entity.")
+        return null
+    parent.add_child(entity_instance)
+    _position_entity_at_player(entity_instance, player)
+    _print_line("Spawned %s at %s's location." % [entity_instance.name, player.name])
+    return entity_instance
+
+func _position_entity_at_player(entity: Node, player: Node) -> void:
+    """Aligns the spawned entity with the player's transform when possible."""
+    if entity == null or player == null:
+        return
+    if entity is Node3D and player is Node3D:
+        entity.global_transform = player.global_transform
+        entity.global_position += Vector3(0, 0, -2.0)
+    elif "global_position" in entity and "global_position" in player:
+        entity.global_position = player.global_position
+
+func _find_player_node() -> Node:
+    """Locates a node representing the player character."""
+    var tree := get_tree()
+    if tree == null:
+        return null
+    var group_matches := tree.get_nodes_in_group("player")
+    if not group_matches.is_empty():
+        return group_matches[0]
+    var scene := tree.get_current_scene()
+    if scene == null:
+        return null
+    var named := scene.get_node_or_null("Player")
+    if named != null:
+        return named
+    return scene
+
+func _ensure_input_action(action_name: String, default_key: int) -> void:
+    """Defines the toggle input action when it does not already exist."""
+    if InputMap.has_action(action_name):
+        return
+    InputMap.add_action(action_name)
+    var event := InputEventKey.new()
+    event.physical_keycode = default_key
+    InputMap.action_add_event(action_name, event)

--- a/src/debug/developer_console/DeveloperConsole.tscn
+++ b/src/debug/developer_console/DeveloperConsole.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://src/debug/developer_console/DeveloperConsole.gd" id="1"]
+
+[node name="DeveloperConsole" type="CanvasLayer"]
+layer = 64
+script = ExtResource("1")
+
+[node name="ConsolePanel" type="PanelContainer" parent="."]
+unique_name_in_owner = true
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+offset_left = 24.0
+offset_top = 24.0
+offset_right = -24.0
+custom_minimum_size = Vector2(0, 280)
+size_flags_vertical = 0
+
+[node name="ConsoleContent" type="VBoxContainer" parent="ConsolePanel"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="ConsoleOutput" type="RichTextLabel" parent="ConsolePanel/ConsoleContent"]
+unique_name_in_owner = true
+size_flags_horizontal = 3
+size_flags_vertical = 3
+scroll_active = true
+bbcode_enabled = true
+
+[node name="ConsoleInput" type="LineEdit" parent="ConsolePanel/ConsoleContent"]
+unique_name_in_owner = true
+placeholder_text = "Enter command..."
+clear_button_enabled = true

--- a/src/debug/entity_inspector/EntityInspectorOverlay.gd
+++ b/src/debug/entity_inspector/EntityInspectorOverlay.gd
@@ -1,0 +1,196 @@
+extends CanvasLayer
+class_name EntityInspectorOverlaySingleton
+"""Autoloaded CanvasLayer that exposes a runtime entity inspection overlay."""
+
+const ENTITY_SCRIPT := preload("res://src/entities/Entity.gd")
+
+const DEFAULT_TOGGLE_ACTION := "debug_toggle_inspector"
+const DEFAULT_RAY_LENGTH := 2000.0
+
+@export var toggle_action := DEFAULT_TOGGLE_ACTION
+@export var selection_button := MOUSE_BUTTON_LEFT
+@export var ray_length := DEFAULT_RAY_LENGTH
+
+@onready var _title_label: Label = %InspectorTitle
+@onready var _subtitle_label: Label = %InspectorSubtitle
+@onready var _component_panel = %ComponentViewerPanel
+
+var _is_active := false
+var _current_entity: ENTITY_SCRIPT = null
+
+func _ready() -> void:
+    """Initialises the overlay and ensures the toggle input binding exists."""
+    visible = false
+    process_mode = Node.PROCESS_MODE_ALWAYS
+    _ensure_input_action(toggle_action, KEY_F1)
+    if is_instance_valid(_component_panel):
+        _component_panel.auto_connect_to_system_testbed = false
+        _component_panel.read_only = true
+        _component_panel.clear_inspection("Click an entity to inspect component data.")
+    _update_title(null)
+    _update_subtitle()
+
+func _unhandled_input(event: InputEvent) -> void:
+    """Listens for the toggle action and selection clicks when active."""
+    if event.is_action_pressed(toggle_action):
+        _toggle_overlay()
+        get_viewport().set_input_as_handled()
+        return
+    if not _is_active:
+        return
+    if event is InputEventMouseButton and event.button_index == selection_button and event.pressed:
+        _select_entity_under_cursor()
+        get_viewport().set_input_as_handled()
+
+func _process(_delta: float) -> void:
+    """Refreshes live data while the overlay is visible."""
+    if not _is_active:
+        return
+    if _current_entity != null and not is_instance_valid(_current_entity):
+        _set_current_entity(null)
+        return
+    if is_instance_valid(_component_panel):
+        _component_panel.sync_controls_from_components()
+    _update_subtitle()
+
+func _toggle_overlay() -> void:
+    """Toggles the overlay visibility and resets state when hiding."""
+    _is_active = not _is_active
+    visible = _is_active
+    if _is_active:
+        if is_instance_valid(_component_panel):
+            _component_panel.clear_inspection("Click an entity to inspect component data.")
+    else:
+        _set_current_entity(null)
+
+func _select_entity_under_cursor() -> void:
+    """Performs a raycast from the mouse position to resolve entities under the cursor."""
+    var viewport := get_viewport()
+    if viewport == null:
+        return
+    var mouse_position := viewport.get_mouse_position()
+    var entity: ENTITY_SCRIPT = _raycast_for_entity_3d(mouse_position)
+    if entity == null:
+        entity = _raycast_for_entity_2d(mouse_position)
+    _set_current_entity(entity)
+
+func _raycast_for_entity_3d(screen_position: Vector2) -> ENTITY_SCRIPT:
+    """Attempts to resolve an entity using a 3D physics ray."""
+    var viewport := get_viewport()
+    if viewport == null:
+        return null
+    var camera: Camera3D = viewport.get_camera_3d()
+    if camera == null:
+        return null
+    var space_state: World3D = camera.get_world_3d()
+    if space_state == null:
+        return null
+    var from := camera.project_ray_origin(screen_position)
+    var direction := camera.project_ray_normal(screen_position)
+    var params := PhysicsRayQueryParameters3D.new()
+    params.from = from
+    params.to = from + direction * ray_length
+    params.collide_with_areas = true
+    params.collide_with_bodies = true
+    var result: Dictionary = space_state.direct_space_state.intersect_ray(params)
+    if result.is_empty():
+        return null
+    var collider: Object = result.get("collider")
+    return _resolve_entity_from_node(collider)
+
+func _raycast_for_entity_2d(screen_position: Vector2) -> ENTITY_SCRIPT:
+    """Fallback query that supports 2D scenes when no 3D camera is present."""
+    var viewport := get_viewport()
+    if viewport == null:
+        return null
+    var world: World2D = viewport.get_world_2d()
+    if world == null:
+        return null
+    var camera: Camera2D = viewport.get_camera_2d()
+    if camera == null:
+        return null
+    var world_point: Vector2 = camera.get_screen_to_world(screen_position)
+    var params := PhysicsPointQueryParameters2D.new()
+    params.position = world_point
+    params.collide_with_areas = true
+    params.collide_with_bodies = true
+    var results: Array = world.direct_space_state.intersect_point(params, 32)
+    if results.is_empty():
+        return null
+    var collider: Object = results[0].get("collider")
+    return _resolve_entity_from_node(collider)
+
+func _resolve_entity_from_node(node: Object) -> ENTITY_SCRIPT:
+    """Walks up the scene tree to locate the nearest Entity ancestor."""
+    if node == null:
+        return null
+    if node is ENTITY_SCRIPT:
+        return node
+    if node is Node:
+        var current: Node = node
+        while current != null:
+            if current is ENTITY_SCRIPT:
+                return current
+            current = current.get_parent()
+    return null
+
+func _set_current_entity(entity: ENTITY_SCRIPT) -> void:
+    """Updates the active entity selection and refreshes the UI."""
+    if entity != null and not is_instance_valid(entity):
+        entity = null
+    if _current_entity == entity:
+        return
+    _current_entity = entity
+    if entity == null:
+        if is_instance_valid(_component_panel):
+            _component_panel.clear_inspection("Click an entity to inspect component data.")
+        _update_title(null)
+    else:
+        if is_instance_valid(_component_panel):
+            _component_panel.inspect_entity(entity)
+        _update_title(entity)
+    _update_subtitle()
+
+func _update_title(entity: ENTITY_SCRIPT) -> void:
+    """Writes the overlay title based on the current entity selection."""
+    if not is_instance_valid(_title_label):
+        return
+    if entity == null:
+        _title_label.text = "Entity Inspector"
+        return
+    var label := entity.name
+    var data = entity.entity_data
+    if data != null:
+        if data.display_name != "":
+            label = data.display_name
+        elif data.entity_id != "":
+            label = data.entity_id.capitalize()
+    _title_label.text = "Inspecting: %s" % label
+
+func _update_subtitle() -> void:
+    """Displays contextual details such as the entity's world position."""
+    if not is_instance_valid(_subtitle_label):
+        return
+    if _current_entity == null or not is_instance_valid(_current_entity):
+        _subtitle_label.text = "Click an entity to inspect component data."
+        return
+    var position: Vector3 = _current_entity.global_position
+    var data = _current_entity.entity_data
+    var entity_id: String = ""
+    if data != null and data.entity_id != "":
+        entity_id = String(data.entity_id)
+    var descriptor: String = entity_id if entity_id != "" else _current_entity.name
+    _subtitle_label.text = "%s — Position %s" % [descriptor, _format_vector3(position)]
+
+func _format_vector3(value: Vector3) -> String:
+    """Formats a Vector3 for compact display in the overlay."""
+    return "(%.2f, %.2f, %.2f)" % [value.x, value.y, value.z]
+
+func _ensure_input_action(action_name: String, default_key: int) -> void:
+    """Creates the toggle input action if it was not defined in the project."""
+    if InputMap.has_action(action_name):
+        return
+    InputMap.add_action(action_name)
+    var event := InputEventKey.new()
+    event.physical_keycode = default_key
+    InputMap.action_add_event(action_name, event)

--- a/src/debug/entity_inspector/EntityInspectorOverlay.tscn
+++ b/src/debug/entity_inspector/EntityInspectorOverlay.tscn
@@ -1,0 +1,74 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://src/debug/entity_inspector/EntityInspectorOverlay.gd" id="1"]
+[ext_resource type="Script" path="res://tests/scripts/system_testbed/ComponentViewerPanel.gd" id="2"]
+
+[node name="EntityInspectorOverlay" type="CanvasLayer"]
+layer = 128
+script = ExtResource("1")
+
+[node name="OverlayRoot" type="MarginContainer" parent="."]
+anchor_left = 1.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+offset_left = -420.0
+offset_top = 24.0
+offset_right = -24.0
+size_flags_vertical = 3
+
+[node name="InspectorPanel" type="PanelContainer" parent="OverlayRoot"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(360, 520)
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="InspectorContent" type="VBoxContainer" parent="OverlayRoot/InspectorPanel"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="InspectorTitle" type="Label" parent="OverlayRoot/InspectorPanel/InspectorContent"]
+unique_name_in_owner = true
+text = "Entity Inspector"
+theme_override_font_sizes/font_size = 20
+
+[node name="InspectorSubtitle" type="Label" parent="OverlayRoot/InspectorPanel/InspectorContent"]
+unique_name_in_owner = true
+text = "Click an entity to inspect component data."
+autowrap_mode = 3
+
+[node name="InspectorSeparator" type="HSeparator" parent="OverlayRoot/InspectorPanel/InspectorContent"]
+
+[node name="ComponentViewerPanel" type="PanelContainer" parent="OverlayRoot/InspectorPanel/InspectorContent"]
+unique_name_in_owner = true
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("2")
+auto_connect_to_system_testbed = false
+read_only = true
+
+[node name="ComponentViewerContent" type="VBoxContainer" parent="OverlayRoot/InspectorPanel/InspectorContent/ComponentViewerPanel"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="ComponentViewerTitle" type="Label" parent="OverlayRoot/InspectorPanel/InspectorContent/ComponentViewerPanel/ComponentViewerContent"]
+text = "Component Data"
+theme_override_font_sizes/font_size = 18
+
+[node name="ComponentViewerScroll" type="ScrollContainer" parent="OverlayRoot/InspectorPanel/InspectorContent/ComponentViewerPanel/ComponentViewerContent"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+scroll_horizontal = false
+
+[node name="ComponentViewerBody" type="VBoxContainer" parent="OverlayRoot/InspectorPanel/InspectorContent/ComponentViewerPanel/ComponentViewerContent/ComponentViewerScroll"]
+unique_name_in_owner = true
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="ComponentViewerPlaceholder" type="Label" parent="OverlayRoot/InspectorPanel/InspectorContent/ComponentViewerPanel/ComponentViewerContent/ComponentViewerScroll/ComponentViewerBody"]
+unique_name_in_owner = true
+text = "Component data will appear here."
+autowrap_mode = 3
+

--- a/src/entities/Entity.gd
+++ b/src/entities/Entity.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Node3D
 class_name Entity
 
 ## Runtime node representing a spawned gameplay entity within the testbed.

--- a/src/entities/Entity.tscn
+++ b/src/entities/Entity.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" path="res://src/entities/Entity.gd" id="1"]
 
-[node name="Entity" type="Node"]
+[node name="Entity" type="Node3D"]
 script = ExtResource("1")

--- a/tests/scenes/DebugOverlay_TestEnvironment.tscn
+++ b/tests/scenes/DebugOverlay_TestEnvironment.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=6 format=3]
+
+[ext_resource type="PackedScene" path="res://tests/scenes/OscillatingEntity3D.tscn" id="1"]
+[ext_resource type="Resource" path="res://assets/entity_archetypes/SkeletonWarrior_EntityData.tres" id="2"]
+
+[sub_resource type="Environment" id="1"]
+ambient_light_source = 2
+ambient_light_color = Color(0.15, 0.18, 0.22, 1)
+ambient_light_energy = 0.7
+
+[sub_resource type="PlaneMesh" id="2"]
+size = Vector2(20, 20)
+
+[sub_resource type="BoxShape3D" id="3"]
+size = Vector3(20, 0.2, 20)
+
+[node name="DebugOverlayTest" type="Node3D"]
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("1")
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D(0.894427, -0.358569, -0.267261, 0.0, 0.597614, -0.801784, 0.447214, 0.716116, 0.535611, 0.0, 6.0, 0.0)
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(0.707107, -0.408248, 0.57735, 0.0, 0.816497, 0.57735, -0.707107, -0.408248, 0.57735, 8.0, 6.0, 10.0)
+current = true
+
+[node name="Ground" type="StaticBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Ground"]
+shape = SubResource("3")
+
+[node name="GroundMesh" type="MeshInstance3D" parent="Ground"]
+mesh = SubResource("2")
+material_override = null
+
+[node name="Player" type="Node3D" parent="."]
+groups = ["player"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 0.5, 0)
+
+[node name="PlayerMesh" type="MeshInstance3D" parent="Player"]
+mesh = SubResource("2")
+scale = Vector3(0.2, 0.02, 0.2)
+
+[node name="EntityA" parent="." instance=ExtResource("1")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.6, 0)
+
+[node name="EntityB" parent="." instance=ExtResource("1")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0.6, -2)
+oscillation_axis = Vector3(0, 1, 0.2)
+oscillation_speed = 1.0
+entity_data = ExtResource("2")
+health_wave_speed = 1.3
+

--- a/tests/scenes/OscillatingEntity3D.tscn
+++ b/tests/scenes/OscillatingEntity3D.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://tests/scripts/debug/OscillatingEntity.gd" id="1"]
+[ext_resource type="Resource" path="res://assets/entity_archetypes/GoblinArcher_EntityData.tres" id="2"]
+
+[sub_resource type="BoxMesh" id="1"]
+size = Vector3(0.8, 0.8, 0.8)
+
+[sub_resource type="BoxShape3D" id="2"]
+size = Vector3(0.8, 0.8, 0.8)
+
+[node name="OscillatingEntity3D" type="Node3D"]
+script = ExtResource("1")
+entity_data = ExtResource("2")
+oscillation_axis = Vector3(1, 0, 0.2)
+oscillation_amplitude = 1.5
+health_wave_amplitude = 16
+
+[node name="Visual" type="MeshInstance3D" parent="."]
+mesh = SubResource("1")
+material_override = null
+
+[node name="Hitbox" type="Area3D" parent="."]
+monitoring = false
+monitorable = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Hitbox"]
+shape = SubResource("2")
+

--- a/tests/scripts/debug/OscillatingEntity.gd
+++ b/tests/scripts/debug/OscillatingEntity.gd
@@ -1,0 +1,66 @@
+extends "res://src/entities/Entity.gd"
+class_name OscillatingEntity
+"""Debug-focused entity that oscillates in space and mutates demo stats for inspection."""
+
+const ULTEnums := preload("res://src/globals/ULTEnums.gd")
+const STATS_COMPONENT := preload("res://src/components/StatsComponent.gd")
+
+@export var oscillation_axis: Vector3 = Vector3(1, 0, 0)
+@export var oscillation_amplitude := 2.0
+@export var oscillation_speed := 1.5
+@export var health_wave_amplitude := 12
+@export var health_wave_speed := 0.8
+
+var _base_position := Vector3.ZERO
+var _time_offset := 0.0
+var _baseline_health := 0
+
+func _ready() -> void:
+    super._ready()
+    _base_position = global_position
+    _time_offset = randf_range(0.0, TAU)
+    if entity_data != null:
+        entity_data = entity_data.duplicate(true)
+        var stats := _extract_stats_component()
+        if stats != null:
+            _baseline_health = stats.health
+
+func _process(_delta: float) -> void:
+    _apply_position_oscillation()
+    _update_demo_stats()
+
+func _apply_position_oscillation() -> void:
+    """Moves the entity along a configurable sine wave for visual feedback."""
+    var axis := oscillation_axis
+    if axis.length() <= 0.01:
+        axis = Vector3(1, 0, 0)
+    var direction := axis.normalized()
+    var time_seconds := Time.get_ticks_msec() / 1000.0
+    var offset := direction * oscillation_amplitude * sin((time_seconds + _time_offset) * oscillation_speed)
+    global_position = _base_position + offset
+
+func _update_demo_stats() -> void:
+    """Animates the entity's health value so inspectors show live updates."""
+    var stats := _extract_stats_component()
+    if stats == null:
+        return
+    var baseline := _baseline_health
+    if baseline == 0:
+        baseline = stats.health
+    var max_health := stats.max_health if stats.max_health > 0 else baseline + health_wave_amplitude
+    var time_seconds := Time.get_ticks_msec() / 1000.0
+    var wave := sin((time_seconds + _time_offset) * health_wave_speed)
+    var delta := int(round(wave * health_wave_amplitude))
+    stats.health = clampi(baseline + delta, 0, max_health)
+
+func _extract_stats_component() -> STATS_COMPONENT:
+    """Helper that resolves the StatsComponent resource when present."""
+    if entity_data == null:
+        return null
+    var key := ULTEnums.ComponentKeys.STATS
+    if not entity_data.has_component(key):
+        return null
+    var stats := entity_data.get_component(key)
+    if stats is STATS_COMPONENT:
+        return stats
+    return null

--- a/tests/scripts/system_testbed/ComponentViewerPanel.gd
+++ b/tests/scripts/system_testbed/ComponentViewerPanel.gd
@@ -12,16 +12,22 @@ const _IGNORED_PROPERTY_NAMES := {
     "script": true,
 }
 
+@export var auto_connect_to_system_testbed := true
+@export var read_only := false
+
 @onready var _component_body: VBoxContainer = %ComponentViewerBody
 @onready var _placeholder_label: Label = %ComponentViewerPlaceholder
 
 var _testbed_root: SYSTEM_TESTBED_SCRIPT
 var _current_target: ENTITY_SCRIPT
+var _active_manifest: Dictionary[StringName, Resource] = {}
+var _property_bindings: Array[Dictionary] = []
 
 func _ready() -> void:
     """Connects to the System Testbed and prepares the initial placeholder state."""
     _show_placeholder("Select an entity to inspect component data.")
-    call_deferred("_initialise_connections")
+    if auto_connect_to_system_testbed:
+        call_deferred("_initialise_connections")
 
 func _initialise_connections() -> void:
     """Resolves the SystemTestbed singleton and listens for selection changes."""
@@ -50,6 +56,16 @@ func _on_active_target_entity_changed(target: Node) -> void:
         _clear_component_views()
         _show_placeholder("Select an entity to inspect component data.")
 
+func inspect_entity(target: Node) -> void:
+    """Public helper allowing external callers to drive entity inspection manually."""
+    _on_active_target_entity_changed(target)
+
+func clear_inspection(message: String = "Select an entity to inspect component data.") -> void:
+    """Clears the current entity selection and displays the supplied placeholder."""
+    _current_target = null
+    _clear_component_views()
+    _show_placeholder(message)
+
 func _rebuild_for_entity(entity: ENTITY_SCRIPT) -> void:
     """Generates editor widgets for each component attached to the entity."""
     _clear_component_views()
@@ -66,6 +82,8 @@ func _rebuild_for_entity(entity: ENTITY_SCRIPT) -> void:
         return
 
     _placeholder_label.visible = false
+    _active_manifest.clear()
+    _property_bindings.clear()
     var keys: Array[String] = []
     for key in manifest.keys():
         keys.append(String(key))
@@ -75,6 +93,7 @@ func _rebuild_for_entity(entity: ENTITY_SCRIPT) -> void:
         var component: Resource = manifest.get(component_key)
         if component == null:
             continue
+        _active_manifest[component_key] = component
         var section := _build_component_section(component_key, component)
         if section != null:
             _component_body.add_child(section)
@@ -104,12 +123,14 @@ func _build_component_section(component_key: StringName, component: Resource) ->
         if editor != null:
             editor.size_flags_horizontal = Control.SIZE_EXPAND_FILL
             property_row.add_child(editor)
+            _register_property_binding(component_key, String(property_info.get("name", "")), property_info.get("type", TYPE_NIL), editor)
         else:
             var value_label := Label.new()
             value_label.text = str(component.get(property_info.get("name")))
             value_label.autowrap_mode = TextServer.AUTOWRAP_WORD
             value_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
             property_row.add_child(value_label)
+            _register_property_binding(component_key, String(property_info.get("name", "")), property_info.get("type", TYPE_NIL), value_label)
 
         section.add_child(property_row)
 
@@ -140,12 +161,15 @@ func _create_property_editor(component: Resource, property_info: Dictionary) -> 
     if property_name == "":
         return null
     var property_type: int = property_info.get("type", TYPE_NIL)
-    var value := component.get(property_name)
+    var value: Variant = component.get(property_name)
     match property_type:
         TYPE_BOOL:
             var checkbox := CheckBox.new()
             checkbox.button_pressed = bool(value)
             checkbox.toggled.connect(_on_boolean_editor_toggled.bind(component, property_name))
+            if read_only:
+                checkbox.disabled = true
+                checkbox.focus_mode = Control.FOCUS_NONE
             return checkbox
         TYPE_INT:
             var int_editor := SpinBox.new()
@@ -156,6 +180,9 @@ func _create_property_editor(component: Resource, property_info: Dictionary) -> 
             int_editor.value = int(value)
             _apply_numeric_hints(int_editor, property_info)
             int_editor.value_changed.connect(_on_numeric_editor_value_changed.bind(component, property_name, true))
+            if read_only:
+                int_editor.editable = false
+                int_editor.focus_mode = Control.FOCUS_NONE
             return int_editor
         TYPE_FLOAT:
             var float_editor := SpinBox.new()
@@ -165,6 +192,9 @@ func _create_property_editor(component: Resource, property_info: Dictionary) -> 
             float_editor.value = float(value)
             _apply_numeric_hints(float_editor, property_info)
             float_editor.value_changed.connect(_on_numeric_editor_value_changed.bind(component, property_name, false))
+            if read_only:
+                float_editor.editable = false
+                float_editor.focus_mode = Control.FOCUS_NONE
             return float_editor
         TYPE_STRING, TYPE_STRING_NAME:
             var line_edit := LineEdit.new()
@@ -172,6 +202,9 @@ func _create_property_editor(component: Resource, property_info: Dictionary) -> 
             line_edit.placeholder_text = "Enter %s" % property_name
             line_edit.text_submitted.connect(_on_text_editor_submitted.bind(component, property_name, property_type))
             line_edit.focus_exited.connect(_on_text_editor_focus_exited.bind(line_edit))
+            if read_only:
+                line_edit.editable = false
+                line_edit.focus_mode = Control.FOCUS_NONE
             return line_edit
     return null
 
@@ -231,6 +264,8 @@ func _clear_component_views() -> void:
             continue
         child.queue_free()
     _placeholder_label.visible = true
+    _property_bindings.clear()
+    _active_manifest.clear()
 
 func _show_placeholder(message: String) -> void:
     """Displays guidance text when no component data is available."""
@@ -254,3 +289,60 @@ func _format_property_label(property_name: String) -> String:
     for i in range(words.size()):
         words[i] = words[i].capitalize()
     return " ".join(words)
+
+func _register_property_binding(component_key: StringName, property_name: String, property_type: int, control: Control) -> void:
+    """Records a UI control so read-only overlays can poll live component values."""
+    if control == null:
+        return
+    var normalized_name := property_name.strip_edges()
+    if normalized_name == "":
+        return
+    var binding := {
+        "component_key": component_key,
+        "property_name": StringName(normalized_name),
+        "type": property_type,
+        "control": control,
+    }
+    _property_bindings.append(binding)
+
+func sync_controls_from_components() -> void:
+    """Updates registered controls from the active entity's component resources."""
+    if not read_only:
+        return
+    if _active_manifest.is_empty():
+        return
+    for binding in _property_bindings:
+        var control: Control = binding.get("control")
+        if control == null or not is_instance_valid(control):
+            continue
+        var component_key: StringName = binding.get("component_key")
+        var component: Resource = _active_manifest.get(component_key)
+        if component == null:
+            continue
+        var property_name: StringName = binding.get("property_name")
+        var value: Variant = component.get(property_name)
+        var property_type: int = int(binding.get("type", TYPE_NIL))
+        control.set_block_signals(true)
+        match property_type:
+            TYPE_BOOL:
+                if control is CheckBox:
+                    control.button_pressed = bool(value)
+            TYPE_INT:
+                if control is SpinBox:
+                    control.value = int(value)
+                elif control is Label:
+                    control.text = str(value)
+            TYPE_FLOAT:
+                if control is SpinBox:
+                    control.value = float(value)
+                elif control is Label:
+                    control.text = str(value)
+            TYPE_STRING, TYPE_STRING_NAME:
+                if control is LineEdit:
+                    control.text = str(value)
+                elif control is Label:
+                    control.text = str(value)
+            _:
+                if control is Label:
+                    control.text = str(value)
+        control.set_block_signals(false)


### PR DESCRIPTION
## Summary
- add a CanvasLayer-based Entity Inspector overlay autoload with mouse picking and live polling
- implement an autoloaded developer console that evaluates Expression commands and spawns archetypes
- refactor the ComponentViewer panel for read-only usage and provide a demo scene with oscillating entities

## Testing
- `python tools/gdscript_parse_helper.py`
- `godot4 --headless --path . --scene res://tests/scenes/DebugOverlay_TestEnvironment.tscn --quit-after 2`


------
https://chatgpt.com/codex/tasks/task_e_68ceca1fb128832096d55c2bb804381d