### PR TITLE
Add constants for combat triggers and improve test harness logging

### DIFF
--- a/tests/scripts/system_testbed/SystemTriggerPanel.gd
+++ b/tests/scripts/system_testbed/SystemTriggerPanel.gd
@@ -13,6 +13,8 @@ const EVENT_BUS_SCRIPT := preload("res://src/globals/EventBus.gd")
 
 const GOBLIN_ARCHER_ARCHETYPE_ID := "GoblinArcher_EntityData.tres"
 const HEALTH_POTION_ITEM_ID := "Health Potion"
+const FIRE_DAMAGE_AMOUNT := 10
+const FIRE_DAMAGE_TYPE := "fire"
 
 @onready var _placeholder_label: Label = %SystemTriggerPlaceholder
 @onready var _actions_container: VBoxContainer = %SystemTriggerActions
@@ -317,7 +319,7 @@ func _on_apply_damage_pressed() -> void:
     if not _combat_system.has_method("apply_damage"):
         push_warning("Test_CombatSystem is missing apply_damage(); trigger skipped.")
         return
-    _combat_system.apply_damage(target, 10, "fire")
+    _combat_system.apply_damage(target, FIRE_DAMAGE_AMOUNT, FIRE_DAMAGE_TYPE)
 
 func _on_spawn_goblin_pressed() -> void:
     """Spawns the Goblin Archer archetype into the test environment."""

--- a/tests/scripts/system_testbed/Test_CombatSystem.gd
+++ b/tests/scripts/system_testbed/Test_CombatSystem.gd
@@ -1,17 +1,27 @@
 extends Node
 class_name Test_CombatSystem
-"""Temporary combat harness used to validate SystemTriggerPanel interactions."""
+"""Temporary combat harness used to validate SystemTriggerPanel interactions.
+
+This utility lives only inside the testbed scene. It mirrors the API shape
+expected from the real CombatSystem so UI engineers can bind buttons and confirm
+payloads before the production gameplay logic exists.
+"""
+
+func _describe_target(target: Node) -> String:
+    """Returns a human readable description of the supplied target."""
+    if not is_instance_valid(target):
+        return "[null]"
+    var path := "(unknown path)"
+    if target.is_inside_tree():
+        path = str(target.get_path())
+    return "%s {path=%s, id=%d}" % [target.name, path, target.get_instance_id()]
 
 func apply_damage(target: Node, amount: int, damage_type: String) -> void:
     """Logs a debug message when damage is applied to confirm wiring works."""
-    var target_name := "[null]"
-    if is_instance_valid(target):
-        target_name = "%s (%s)" % [target.name, target.get_path()]
-    print("[Test_CombatSystem] apply_damage -> target=%s, amount=%d, type=%s" % [target_name, amount, damage_type])
+    var target_label := _describe_target(target)
+    print("[Test_CombatSystem] apply_damage -> target=%s, amount=%d, type=%s" % [target_label, amount, damage_type])
 
 func kill_target(target: Node) -> void:
     """Logs a debug message when a kill trigger is invoked."""
-    var target_name := "[null]"
-    if is_instance_valid(target):
-        target_name = "%s (%s)" % [target.name, target.get_path()]
-    print("[Test_CombatSystem] kill_target -> target=%s" % target_name)
+    var target_label := _describe_target(target)
+    print("[Test_CombatSystem] kill_target -> target=%s" % target_label)


### PR DESCRIPTION
## Summary
- add constants describing the fire damage trigger so the panel reuses the same values when invoking the combat harness
- expand the temporary combat system harness with richer documentation and debug output that highlights the current target metadata

## Testing
- godot4 --headless --path . --quit

------
https://chatgpt.com/codex/tasks/task_e_68cef14bcec88320bb2266c37926b0a8