### PR TITLE
Fix Godot parser errors and normalize headless tests

### DIFF
--- a/.godot/global_script_class_cache.cfg
+++ b/.godot/global_script_class_cache.cfg
@@ -31,7 +31,7 @@ list=[{
 "language": &"GDScript",
 "path": "res://src/core/BaseItem.gd"
 }, {
-"base": &"",
+"base": &"Resource",
 "class": &"BaseMeleeSkill",
 "icon": "",
 "is_abstract": false,
@@ -39,7 +39,7 @@ list=[{
 "language": &"GDScript",
 "path": "res://src/core/skills/BaseMeleeSkill.gd"
 }, {
-"base": &"",
+"base": &"Resource",
 "class": &"BaseRangedSkill",
 "icon": "",
 "is_abstract": false,

--- a/src/components/InventoryComponent.gd
+++ b/src/components/InventoryComponent.gd
@@ -15,6 +15,7 @@ const BASE_ITEM_SCRIPT := preload("res://src/core/BaseItem.gd")
 ##   - "item_resource": BaseItem (the actual item resource)
 ##   - "quantity": int (number of items in this stack)
 @export var items: Array[Dictionary] = []
+@export var owner_entity_id: StringName = &""
 
 ## Adds an item to the inventory, handling stacking if the item already exists.
 func add_item(item_resource: BaseItem, quantity: int = 1) -> void:
@@ -46,7 +47,7 @@ func add_item(item_resource: BaseItem, quantity: int = 1) -> void:
     var event_payload = {
         "item_id": item_resource.item_id,
         "quantity": quantity,
-        "owner_id": name, # Assuming the component's owner node has a unique name
+        "owner_id": owner_entity_id,
         "source": &"inventory_component_add", # Or a more specific source if known
         # "metadata": item_resource.metadata # If BaseItem had metadata
     }
@@ -111,7 +112,8 @@ func _get_event_bus() -> Node:
         if singleton is Node:
             return singleton
 
-    var scene_tree := get_tree()
+    var main_loop := Engine.get_main_loop()
+    var scene_tree := main_loop as SceneTree
     if scene_tree == null:
         return null
 

--- a/src/core/skills/BaseMeleeSkill.gd
+++ b/src/core/skills/BaseMeleeSkill.gd
@@ -1,4 +1,4 @@
-extends "res://src/core/Skill.gd"
+extends "res://src/components/Skill.gd"
 class_name BaseMeleeSkill
 
 ## A specialized Skill resource for the Melee category.

--- a/src/core/skills/BaseRangedSkill.gd
+++ b/src/core/skills/BaseRangedSkill.gd
@@ -1,4 +1,4 @@
-extends "res://src/core/Skill.gd"
+extends "res://src/components/Skill.gd"
 class_name BaseRangedSkill
 
 ## A specialized Skill resource for the Ranged category.

--- a/tests/eventbus_replay_runner.gd
+++ b/tests/eventbus_replay_runner.gd
@@ -109,7 +109,7 @@ func _run() -> void:
 
     if args["export_log_path"] is String and not String(args["export_log_path"]).is_empty():
         var export_path := _normalize_path(String(args["export_log_path"]))
-        var export_error := harness_root.call("export_log", export_path)
+        var export_error: int = int(harness_root.call("export_log", export_path))
         if export_error != OK:
             var export_message := "Failed to export harness log to %s (error %s)." % [
                 export_path,
@@ -126,7 +126,7 @@ func _run() -> void:
                 "path": export_path,
             })
 
-    var combined_log_text := log_label.get_parsed_text()
+    var combined_log_text: String = log_label.get_parsed_text()
     if args["echo_log"]:
         _emit_json({
             "type": "eventbus_replay_echo",
@@ -228,7 +228,7 @@ func _load_replay_entries(path: String) -> Dictionary:
             ]
         }
 
-    var data := json.data
+    var data: Variant = json.data
     if typeof(data) != TYPE_ARRAY:
         return {"error": "Replay JSON root must be an array of dictionaries."}
 
@@ -324,7 +324,7 @@ func _parse_success_entry(message: String, timestamp: String) -> Dictionary:
     var payload_split := message.find(" with payload ")
     if payload_split == -1:
         payload_split = message.length()
-    var signal_name := message.substr("Replayed ".length, payload_split - "Replayed ".length)
+    var signal_name := message.substr("Replayed ".length(), payload_split - "Replayed ".length())
     return {
         "type": "eventbus_replay_entry",
         "timestamp": timestamp,
@@ -337,7 +337,7 @@ func _parse_failure_entry(message: String, timestamp: String) -> Dictionary:
     var payload_split := message.find(" with payload ")
     if payload_split == -1:
         payload_split = message.length()
-    var signal_name := message.substr("Failed to replay ".length, payload_split - "Failed to replay ".length)
+    var signal_name := message.substr("Failed to replay ".length(), payload_split - "Failed to replay ".length())
     return {
         "type": "eventbus_replay_entry",
         "timestamp": timestamp,

--- a/tests/scripts/Testbed.gd
+++ b/tests/scripts/Testbed.gd
@@ -95,7 +95,7 @@ func _render_components() -> void:
 
 func _render_resource_properties(resource: Resource, resource_name: String, indent_level: int = 0) -> void:
     """Builds property rows for every exported member on the supplied resource."""
-    var exclusions := PROPERTY_EXCLUSIONS.get(resource_name, [])
+    var exclusions: Array = PROPERTY_EXCLUSIONS.get(resource_name, []) as Array
     for property_info in resource.get_script().get_script_property_list():
         var property_name: String = property_info.get("name", "")
         if property_name == "":
@@ -134,7 +134,7 @@ func _create_editor_for_property(resource: Resource, property_info: Dictionary) 
     var property_type: int = property_info.get("type", TYPE_NIL)
     var hint: int = property_info.get("hint", PROPERTY_HINT_NONE)
     var hint_string: String = property_info.get("hint_string", "")
-    var value := resource.get(property_name)
+    var value: Variant = resource.get(property_name)
 
     match property_type:
         TYPE_BOOL:
@@ -221,7 +221,7 @@ func _build_variant_editor(resource: Resource, property_name: String, value: Var
     """Creates a text editor that serialises complex Variant data."""
     var text_edit := TextEdit.new()
     text_edit.custom_minimum_size = Vector2(0, 120)
-    text_edit.wrap_mode = TextEdit.WRAP_WORD_SMART
+    text_edit.wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
     text_edit.text = var_to_str(value)
     text_edit.focus_exited.connect(
         _on_variant_editor_focus_exited.bind(text_edit, resource, property_name)
@@ -276,7 +276,7 @@ func _on_variant_editor_focus_exited(
         push_warning("Value for %s cannot be empty." % property_name)
         text_edit.text = var_to_str(resource.get(property_name))
         return
-    var parsed_value := str_to_var(trimmed)
+    var parsed_value: Variant = str_to_var(trimmed)
     if parsed_value == null and trimmed.to_lower() != "null":
         push_warning("Failed to parse value for %s. Use Godot variant syntax (e.g. [] or {\"key\": value})." % property_name)
         text_edit.text = var_to_str(resource.get(property_name))

--- a/tests/scripts/system_testbed/SystemTriggerPanel.gd
+++ b/tests/scripts/system_testbed/SystemTriggerPanel.gd
@@ -39,14 +39,14 @@ var _testbed_root: SYSTEM_TESTBED_SCRIPT
 var _payload_field_registry: Dictionary = {}
 
 func set_attack_damage_type(value: StringName) -> void:
-        attack_damage_type = value
-        if is_inside_tree():
-                _refresh_attack_button_label()
+	attack_damage_type = value
+	if is_inside_tree():
+		_refresh_attack_button_label()
 
 func set_health_potion_item_id(value: StringName) -> void:
-        health_potion_item_id = value
-        if is_inside_tree():
-                _refresh_inventory_button_label()
+	health_potion_item_id = value
+	if is_inside_tree():
+		_refresh_inventory_button_label()
 
 func _ready() -> void:
 	"""Initializes connections and builds the EventBus trigger controls."""
@@ -55,13 +55,13 @@ func _ready() -> void:
 	_subscribe_to_target_updates()
 	_subscribe_to_spawner_updates()
 	_update_button_states()
-        _configure_event_bus_controls()
-        _update_placeholder_visibility()
-        _refresh_spawn_selected_button_label()
-        _refresh_attack_button_label()
-        _refresh_status_effect_button_label()
-        _refresh_kill_button_label()
-        _refresh_inventory_button_label()
+	_configure_event_bus_controls()
+	_update_placeholder_visibility()
+	_refresh_spawn_selected_button_label()
+	_refresh_attack_button_label()
+	_refresh_status_effect_button_label()
+	_refresh_kill_button_label()
+	_refresh_inventory_button_label()
 
 func _wire_buttons() -> void:
 	"""Safely connects UI button presses to their handlers."""
@@ -75,17 +75,17 @@ func _wire_buttons() -> void:
 	else:
 		push_warning("SystemTriggerPanel missing AttackTargetButton; attack trigger disabled.")
 
-        if is_instance_valid(_attack_damage_field):
-                _attack_damage_field.value_changed.connect(
-                        func(_value: float) -> void:
-                                _refresh_attack_button_label()
-                )
-                _attack_damage_field.tooltip_text = _attack_damage_missing_message()
-        else:
-                push_warning("SystemTriggerPanel missing AttackDamageSpinner; you must select a damage value before triggering an attack.")
+	if is_instance_valid(_attack_damage_field):
+		_attack_damage_field.value_changed.connect(
+			func(_value: float) -> void:
+				_refresh_attack_button_label()
+		)
+		_attack_damage_field.tooltip_text = _attack_damage_missing_message()
+	else:
+		push_warning("SystemTriggerPanel missing AttackDamageSpinner; you must select a damage value before triggering an attack.")
 
-        if is_instance_valid(_kill_target_button):
-                _kill_target_button.pressed.connect(_on_kill_target_pressed)
+	if is_instance_valid(_kill_target_button):
+		_kill_target_button.pressed.connect(_on_kill_target_pressed)
 	else:
 		push_warning("SystemTriggerPanel missing KillTargetButton; kill trigger disabled.")
 
@@ -99,24 +99,24 @@ func _wire_buttons() -> void:
 	else:
 		push_warning("SystemTriggerPanel missing AssignStatusEffectButton; status effect trigger disabled.")
 
-        if is_instance_valid(_status_effect_name_field):
-                _status_effect_name_field.text_changed.connect(
-                        func(_text: String) -> void:
-                                _refresh_status_effect_button_label()
-                )
-                _status_effect_name_field.placeholder_text = _status_effect_name_missing_message()
-                _status_effect_name_field.tooltip_text = _status_effect_name_missing_message()
-        else:
-                push_warning("SystemTriggerPanel missing StatusEffectNameField; status effect trigger requires manual effect name entry.")
+	if is_instance_valid(_status_effect_name_field):
+		_status_effect_name_field.text_changed.connect(
+			func(_text: String) -> void:
+				_refresh_status_effect_button_label()
+		)
+		_status_effect_name_field.placeholder_text = _status_effect_name_missing_message()
+		_status_effect_name_field.tooltip_text = _status_effect_name_missing_message()
+	else:
+		push_warning("SystemTriggerPanel missing StatusEffectNameField; status effect trigger requires manual effect name entry.")
 
-        if is_instance_valid(_status_effect_duration_field):
-                _status_effect_duration_field.value_changed.connect(
-                        func(_value: float) -> void:
-                                _refresh_status_effect_button_label()
-                )
-                _status_effect_duration_field.tooltip_text = _status_effect_duration_missing_message()
-        else:
-                push_warning("SystemTriggerPanel missing StatusEffectDurationSpinner; you must select a duration before assigning a status effect.")
+	if is_instance_valid(_status_effect_duration_field):
+		_status_effect_duration_field.value_changed.connect(
+			func(_value: float) -> void:
+				_refresh_status_effect_button_label()
+		)
+		_status_effect_duration_field.tooltip_text = _status_effect_duration_missing_message()
+	else:
+		push_warning("SystemTriggerPanel missing StatusEffectDurationSpinner; you must select a duration before assigning a status effect.")
 
 	if is_instance_valid(_emit_event_button):
 		_emit_event_button.pressed.connect(_on_emit_event_pressed)
@@ -311,23 +311,23 @@ func _create_editor_control(key: StringName, expected_rule: Variant) -> Control:
 			float_spin.allow_greater = true
 			float_spin.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 			return float_spin
-                TYPE_ARRAY, TYPE_DICTIONARY:
-                        var text_edit := TextEdit.new()
-                        text_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-                        text_edit.size_flags_vertical = Control.SIZE_EXPAND_FILL
-                        text_edit.custom_minimum_size = Vector2(0, 80)
-                        text_edit.wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
-                        var placeholder := _payload_value_missing_message(key)
-                        text_edit.placeholder_text = placeholder
-                        text_edit.tooltip_text = placeholder
-                        return text_edit
+		TYPE_ARRAY, TYPE_DICTIONARY:
+			var text_edit := TextEdit.new()
+			text_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+			text_edit.size_flags_vertical = Control.SIZE_EXPAND_FILL
+			text_edit.custom_minimum_size = Vector2(0, 80)
+			text_edit.wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
+			var placeholder := _payload_value_missing_message(key)
+			text_edit.placeholder_text = placeholder
+			text_edit.tooltip_text = placeholder
+			return text_edit
 		_:
-                        var line_edit := LineEdit.new()
-                        line_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-                        var message := _payload_value_missing_message(key)
-                        line_edit.placeholder_text = message
-                        line_edit.tooltip_text = message
-                        return line_edit
+			var line_edit := LineEdit.new()
+			line_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+			var message := _payload_value_missing_message(key)
+			line_edit.placeholder_text = message
+			line_edit.tooltip_text = message
+			return line_edit
 
 func _set_control_enabled(control: Control, enabled: bool) -> void:
 	if control is LineEdit:
@@ -356,33 +356,33 @@ func _update_event_description(text: String) -> void:
 	_event_description_label.text = text
 
 func _describe_expected_rule(expected_rule: Variant) -> String:
-        if typeof(expected_rule) == TYPE_ARRAY:
-                var names := PackedStringArray()
-                for value in expected_rule:
-                        names.append(type_string(int(value)))
-                return ", ".join(names)
-        return type_string(int(expected_rule))
+	if typeof(expected_rule) == TYPE_ARRAY:
+		var names := PackedStringArray()
+		for value in expected_rule:
+			names.append(type_string(int(value)))
+		return ", ".join(names)
+	return type_string(int(expected_rule))
 
 func _payload_value_missing_message(key: StringName) -> String:
-        return "You must select a value for %s." % String(key)
+	return "You must select a value for %s." % String(key)
 
 func _attack_damage_missing_message() -> String:
-        return "You must select a damage value before triggering an attack."
+	return "You must select a damage value before triggering an attack."
 
 func _status_effect_name_missing_message() -> String:
-        return "You must select a status effect name before assigning it to the target."
+	return "You must select a status effect name before assigning it to the target."
 
 func _status_effect_duration_missing_message() -> String:
-        return "You must select a status effect duration before assigning it to the target."
+	return "You must select a status effect duration before assigning it to the target."
 
 func _inventory_item_missing_message() -> String:
-        return "You must select an item identifier before granting inventory items."
+	return "You must select an item identifier before granting inventory items."
 
 func _attack_damage_type_is_missing() -> bool:
-        return String(attack_damage_type).is_empty()
+	return String(attack_damage_type).is_empty()
 
 func _attack_damage_type_missing_message() -> String:
-        return "You must select an attack damage type before triggering an attack."
+	return "You must select an attack damage type before triggering an attack."
 
 func _resolve_primary_type(expected_rule: Variant) -> int:
 	if typeof(expected_rule) == TYPE_ARRAY and expected_rule.size() > 0:
@@ -402,42 +402,42 @@ func _on_attack_target_pressed() -> void:
 		push_warning("Test_CombatSystem is missing attack_target(); trigger skipped.")
 		return
 
-        var amount := _get_attack_damage_amount()
-        if amount == null:
-                push_warning(_attack_damage_missing_message())
-                _refresh_attack_button_label()
-                return
+	var amount: Variant = _get_attack_damage_amount()
+	if amount == null:
+		push_warning(_attack_damage_missing_message())
+		_refresh_attack_button_label()
+		return
 
-        if int(amount) < 0:
-                push_warning("Attack damage must be zero or greater.")
-                return
+	if int(amount) < 0:
+		push_warning("Attack damage must be zero or greater.")
+		return
 
-        if _attack_damage_type_is_missing():
-                push_warning(_attack_damage_type_missing_message())
-                return
+	if _attack_damage_type_is_missing():
+		push_warning(_attack_damage_type_missing_message())
+		return
 
-        _combat_system.attack_target(target, int(amount), attack_damage_type)
+	_combat_system.attack_target(target, int(amount), attack_damage_type)
 
 func _get_attack_damage_amount() -> Variant:
-        if is_instance_valid(_attack_damage_field):
-                return int(round(_attack_damage_field.value))
-        return null
+	if is_instance_valid(_attack_damage_field):
+		return int(round(_attack_damage_field.value))
+	return null
 
 func _refresh_attack_button_label() -> void:
-        if not is_instance_valid(_attack_button):
-                return
-        var amount := _get_attack_damage_amount()
-        if amount == null:
-                _attack_button.text = _attack_damage_missing_message()
-                return
-        if _attack_damage_type_is_missing():
-                _attack_button.text = _attack_damage_type_missing_message()
-                return
-        var target := _get_active_target()
-        var target_label := "Target"
-        if is_instance_valid(target):
-                target_label = target.name
-        _attack_button.text = "Attack %s for %d Damage" % [target_label, int(amount)]
+	if not is_instance_valid(_attack_button):
+		return
+	var amount: Variant = _get_attack_damage_amount()
+	if amount == null:
+		_attack_button.text = _attack_damage_missing_message()
+		return
+	if _attack_damage_type_is_missing():
+		_attack_button.text = _attack_damage_type_missing_message()
+		return
+	var target := _get_active_target()
+	var target_label := "Target"
+	if is_instance_valid(target):
+		target_label = target.name
+	_attack_button.text = "Attack %s for %d Damage" % [target_label, int(amount)]
 
 func _on_assign_status_effect_pressed() -> void:
 	"""Invokes the temporary combat system to assign a status effect."""
@@ -452,76 +452,76 @@ func _on_assign_status_effect_pressed() -> void:
 		push_warning("Test_CombatSystem is missing assign_status_effect(); trigger skipped.")
 		return
 
-        var effect_name_variant := _get_status_effect_name()
-        if effect_name_variant == null:
-                push_warning(_status_effect_name_missing_message())
-                _refresh_status_effect_button_label()
-                return
+	var effect_name_variant: Variant = _get_status_effect_name()
+	if effect_name_variant == null:
+		push_warning(_status_effect_name_missing_message())
+		_refresh_status_effect_button_label()
+		return
 
-        var effect_name := String(effect_name_variant)
-        if effect_name.strip_edges().is_empty():
-                push_warning(_status_effect_name_missing_message())
-                _refresh_status_effect_button_label()
-                return
+	var effect_name := String(effect_name_variant)
+	if effect_name.strip_edges().is_empty():
+		push_warning(_status_effect_name_missing_message())
+		_refresh_status_effect_button_label()
+		return
 
-        var duration := _get_status_effect_duration()
-        if duration == null:
-                push_warning(_status_effect_duration_missing_message())
-                _refresh_status_effect_button_label()
-                return
+	var duration: Variant = _get_status_effect_duration()
+	if duration == null:
+		push_warning(_status_effect_duration_missing_message())
+		_refresh_status_effect_button_label()
+		return
 
-        if int(duration) < 1:
-                push_warning("Status effect duration must be at least 1 turn.")
-                return
+	if int(duration) < 1:
+		push_warning("Status effect duration must be at least 1 turn.")
+		return
 
-        _combat_system.assign_status_effect(target, effect_name.strip_edges(), int(duration))
+	_combat_system.assign_status_effect(target, effect_name.strip_edges(), int(duration))
 
 func _get_status_effect_name() -> Variant:
-        if is_instance_valid(_status_effect_name_field):
-                return _status_effect_name_field.text
-        return null
+	if is_instance_valid(_status_effect_name_field):
+		return _status_effect_name_field.text
+	return null
 
 func _get_status_effect_duration() -> Variant:
-        if is_instance_valid(_status_effect_duration_field):
-                return int(round(_status_effect_duration_field.value))
-        return null
+	if is_instance_valid(_status_effect_duration_field):
+		return int(round(_status_effect_duration_field.value))
+	return null
 
 func _refresh_status_effect_button_label() -> void:
-        if not is_instance_valid(_assign_status_effect_button):
-                return
-        var effect_name_variant := _get_status_effect_name()
-        if effect_name_variant == null:
-                _assign_status_effect_button.text = _status_effect_name_missing_message()
-                return
-        var effect_name := String(effect_name_variant).strip_edges()
-        if effect_name.is_empty():
-                _assign_status_effect_button.text = _status_effect_name_missing_message()
-                return
-        var duration_variant := _get_status_effect_duration()
-        if duration_variant == null:
-                _assign_status_effect_button.text = _status_effect_duration_missing_message()
-                return
-        var duration := int(duration_variant)
-        if duration < 1:
-                _assign_status_effect_button.text = "Status effect duration must be at least 1 turn."
-                return
-        var target := _get_active_target()
-        var target_label := "Target"
-        if is_instance_valid(target):
-                target_label = target.name
-        _assign_status_effect_button.text = "Assign %s (%d turns) to %s" % [effect_name, duration, target_label]
+	if not is_instance_valid(_assign_status_effect_button):
+		return
+	var effect_name_variant: Variant = _get_status_effect_name()
+	if effect_name_variant == null:
+		_assign_status_effect_button.text = _status_effect_name_missing_message()
+		return
+	var effect_name := String(effect_name_variant).strip_edges()
+	if effect_name.is_empty():
+		_assign_status_effect_button.text = _status_effect_name_missing_message()
+		return
+	var duration_variant: Variant = _get_status_effect_duration()
+	if duration_variant == null:
+		_assign_status_effect_button.text = _status_effect_duration_missing_message()
+		return
+	var duration := int(duration_variant)
+	if duration < 1:
+		_assign_status_effect_button.text = "Status effect duration must be at least 1 turn."
+		return
+	var target := _get_active_target()
+	var target_label := "Target"
+	if is_instance_valid(target):
+		target_label = target.name
+	_assign_status_effect_button.text = "Assign %s (%d turns) to %s" % [effect_name, duration, target_label]
 
 func _refresh_inventory_button_label() -> void:
-        if not is_instance_valid(_give_health_potion_button):
-                return
-        if String(health_potion_item_id).is_empty():
-                _give_health_potion_button.text = _inventory_item_missing_message()
-                return
-        var target := _get_active_target()
-        var target_label := "Target"
-        if is_instance_valid(target):
-                target_label = target.name
-        _give_health_potion_button.text = "Give '%s' to %s" % [String(health_potion_item_id), target_label]
+	if not is_instance_valid(_give_health_potion_button):
+		return
+	if String(health_potion_item_id).is_empty():
+		_give_health_potion_button.text = _inventory_item_missing_message()
+		return
+	var target := _get_active_target()
+	var target_label := "Target"
+	if is_instance_valid(target):
+		target_label = target.name
+	_give_health_potion_button.text = "Give '%s' to %s" % [String(health_potion_item_id), target_label]
 
 func _refresh_kill_button_label() -> void:
 	if not is_instance_valid(_kill_target_button):
@@ -550,23 +550,23 @@ func _on_spawn_selected_pressed() -> void:
 		push_warning("Failed to spawn %s via EntitySpawnerPanel." % archetype_id)
 
 func _on_give_health_potion_pressed() -> void:
-        """Invokes the temporary inventory system to hand the target a health potion."""
-        var target := _get_active_target()
-        if target == null:
-                push_warning("Select an entity in the Scene Inspector before granting inventory items.")
-                return
-        var inventory := _resolve_inventory_system()
-        if inventory == null:
-                push_warning("Test_InventorySystem node is unavailable; cannot grant items.")
-                return
-        if not inventory.has_method("add_item_to_entity"):
-                push_warning("Test_InventorySystem is missing add_item_to_entity(); trigger skipped.")
-                return
-        if String(health_potion_item_id).is_empty():
-                push_warning(_inventory_item_missing_message())
-                _refresh_inventory_button_label()
-                return
-        inventory.add_item_to_entity(target, health_potion_item_id)
+	"""Invokes the temporary inventory system to hand the target a health potion."""
+	var target := _get_active_target()
+	if target == null:
+		push_warning("Select an entity in the Scene Inspector before granting inventory items.")
+		return
+	var inventory := _resolve_inventory_system()
+	if inventory == null:
+		push_warning("Test_InventorySystem node is unavailable; cannot grant items.")
+		return
+	if not inventory.has_method("add_item_to_entity"):
+		push_warning("Test_InventorySystem is missing add_item_to_entity(); trigger skipped.")
+		return
+	if String(health_potion_item_id).is_empty():
+		push_warning(_inventory_item_missing_message())
+		_refresh_inventory_button_label()
+		return
+	inventory.add_item_to_entity(target, health_potion_item_id)
 
 func _on_kill_target_pressed() -> void:
 	"""Invokes the temporary combat system to simulate a kill."""
@@ -685,10 +685,10 @@ func _on_active_target_entity_changed(_target: Node) -> void:
 	_update_button_states()
 
 func _update_button_states() -> void:
-        """Enables target-dependent triggers only when a selection exists."""
-        var has_target := is_instance_valid(_get_active_target())
-        if is_instance_valid(_spawn_selected_button):
-                var spawner := _resolve_entity_spawner_panel()
+	"""Enables target-dependent triggers only when a selection exists."""
+	var has_target := is_instance_valid(_get_active_target())
+	if is_instance_valid(_spawn_selected_button):
+		var spawner := _resolve_entity_spawner_panel()
 		var can_spawn := false
 		if spawner != null and spawner.has_method("get_selected_archetype_id"):
 			can_spawn = not spawner.get_selected_archetype_id().strip_edges().is_empty()
@@ -707,14 +707,14 @@ func _update_button_states() -> void:
 		_set_control_enabled(_status_effect_name_field, has_target)
 	if is_instance_valid(_status_effect_duration_field):
 		_set_control_enabled(_status_effect_duration_field, has_target)
-        if is_instance_valid(_emit_event_button):
-                _emit_event_button.disabled = not EVENT_BUS_SCRIPT.is_singleton_ready() or _event_selector.item_count == 0
-        _update_target_status_label()
-        _refresh_spawn_selected_button_label()
-        _refresh_attack_button_label()
-        _refresh_status_effect_button_label()
-        _refresh_kill_button_label()
-        _refresh_inventory_button_label()
+	if is_instance_valid(_emit_event_button):
+		_emit_event_button.disabled = not EVENT_BUS_SCRIPT.is_singleton_ready() or _event_selector.item_count == 0
+	_update_target_status_label()
+	_refresh_spawn_selected_button_label()
+	_refresh_attack_button_label()
+	_refresh_status_effect_button_label()
+	_refresh_kill_button_label()
+	_refresh_inventory_button_label()
 
 func _refresh_spawn_selected_button_label() -> void:
 	if not is_instance_valid(_spawn_selected_button):


### PR DESCRIPTION
## Summary
- export the owning entity identifier in `InventoryComponent` and resolve the EventBus through `Engine.get_main_loop()` for headless safety
- point the melee and ranged skill resources at the correct base class and update the global script cache
- add explicit typing and indentation fixes across the system testbed, Testbed UI, and eventbus replay runner to clear parser warnings

## Testing
- python tools/gdscript_parse_helper.py .
- godot4 --headless --path . --import
- godot4 --headless --path . --quit-after 1 --scene res://tests/Sprint2Val.tscn


------
https://chatgpt.com/codex/tasks/task_e_68cf16c750648320a6ec8625abb5cd2f