### PR TITLE
Fix EntityData export parsing and type annotations

### DIFF
--- a/tests/scripts/system_testbed/ComponentViewerPanel.gd
+++ b/tests/scripts/system_testbed/ComponentViewerPanel.gd
@@ -73,11 +73,11 @@ func _rebuild_for_entity(entity: ENTITY_SCRIPT) -> void:
     if entity == null or not is_instance_valid(entity):
         _show_placeholder("Select an entity to inspect component data.")
         return
-    var data := entity.entity_data
+    var data: EntityData = entity.entity_data
     if data == null:
         _show_placeholder("The selected entity does not expose EntityData.")
         return
-    var manifest := data.list_components()
+    var manifest: Dictionary = data.list_components()
     if manifest.is_empty():
         _show_placeholder("The selected entity has no registered components.")
         return


### PR DESCRIPTION
## Summary
- replace the EntityData components export with a plain dictionary export that uses explicit setter/getter logic so Godot can parse the resource script
- normalise indentation to spaces and add missing type annotations/return paths in EntityData helpers to satisfy the 4.4.1 parser
- type the ComponentViewerPanel entity manifest access so editor utilities can safely use EntityData

## Testing
- python tools/gdscript_parse_helper.py src tests
- godot4 --headless --path . --check-only --verbose *(terminated manually after confirming resources loaded without new parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cff92b80908320bc9e9293e89b56c1