### PR TITLE
Add modifier utilities to StatsComponent

### DIFF
--- a/EngineersManual.md
+++ b/EngineersManual.md
@@ -72,7 +72,7 @@ The Architectural Style Guide mandates composition over inheritance, a strict da
 - **Immediate guidance:**
   1. Replace direct node access with `EntityData` lookups: iterate `Entity` nodes, call `entity.entity_data.get_component(ULTEnums.ComponentKeys.STATUS)` to fetch `StatusComponent` resources, and operate on their arrays.
   2. Emit `status_effect_applied`/`status_effect_ended` via `emit_event()` rather than direct bus usage to maintain the abstraction.
-  3. Reconcile stat adjustments by applying modifiers to the owning `StatsComponent` resource (`apply_stat_mod` or equivalent) rather than assuming node methods exist. Where helper methods are missing, extend `StatsComponent` with pure-data utilities instead of referencing scene nodes.
+  3. Reconcile stat adjustments by applying modifiers to the owning `StatsComponent` resource (`apply_modifiers()` / `revert_modifiers()` with `apply_stat_mod()` kept for legacy callers) rather than assuming node methods exist. Where helper methods are missing, extend `StatsComponent` with pure-data utilities instead of referencing scene nodes.
   4. Document how new effects enter `StatusComponent` (likely through quest/combat systems) and ensure they duplicate `StatusFX` resources before storage, as flagged by the TODO block.
 
 ## 6. Diagnostics & Tooling

--- a/devdocs/Designers/StatsComponentManual.md
+++ b/devdocs/Designers/StatsComponentManual.md
@@ -94,4 +94,4 @@ Each section groups related properties. "Common range" records the values most b
 
 ## Runtime helpers
 
-The component exposes convenience methods for common stat mutations: `apply_damage()`, `heal()`, `spend_energy()`, `restore_energy()`, `spend_action_points()`, `restore_action_points()`, status and trait mutators, a bundled `apply_stat_mod()` helper, and `reset_for_new_run()` to refresh per-run resources.【F:src/components/StatsComponent.gd†L174-L308】 Use these utilities instead of rewriting bespoke logic so downstream systems inherit the same clamping rules described above.
+The component exposes convenience methods for common stat mutations: `apply_damage()`, `heal()`, `spend_energy()`, `restore_energy()`, `spend_action_points()`, `restore_action_points()`, status and trait mutators, bundled `apply_modifiers()` / `revert_modifiers()` helpers (with `apply_stat_mod()` retained for compatibility), and `reset_for_new_run()` to refresh per-run resources.【F:src/components/StatsComponent.gd†L174-L452】 Use these utilities instead of rewriting bespoke logic so downstream systems inherit the same clamping rules described above.

--- a/src/systems/StatusSystem.gd
+++ b/src/systems/StatusSystem.gd
@@ -102,43 +102,7 @@ func _revert_effect_modifiers(stats_component: StatsComponent, effect: StatusFX)
     var modifiers := effect.modifiers
     if modifiers == null or modifiers.is_empty():
         return
-
-    var inverse: Dictionary = {}
-    for key in modifiers.keys():
-        var value := modifiers[key]
-        match key:
-            "add_short_status", "add_long_status":
-                if value is Array:
-                    var removal: Array = []
-                    if inverse.has("remove_status"):
-                        removal = inverse["remove_status"]
-                    for status in value:
-                        removal.append(status)
-                    inverse["remove_status"] = removal
-            "traits_to_add":
-                if value is Array:
-                    var traits_to_remove: Array = []
-                    if inverse.has("traits_to_remove"):
-                        traits_to_remove = inverse["traits_to_remove"]
-                    for trait in value:
-                        traits_to_remove.append(trait)
-                    inverse["traits_to_remove"] = traits_to_remove
-            "traits_to_remove":
-                if value is Array:
-                    var traits_to_add: Array = []
-                    if inverse.has("traits_to_add"):
-                        traits_to_add = inverse["traits_to_add"]
-                    for trait in value:
-                        traits_to_add.append(trait)
-                    inverse["traits_to_add"] = traits_to_add
-            _:
-                if typeof(value) == TYPE_INT or typeof(value) == TYPE_FLOAT:
-                    inverse[key] = -value
-
-    if inverse.is_empty():
-        return
-
-    stats_component.apply_stat_mod(inverse)
+    stats_component.revert_modifiers(modifiers)
 
 ## Broadcasts the canonical status_effect_ended payload via the shared EventBus.
 func _emit_effect_ended(entity_id: StringName, effect: StatusFX) -> void:


### PR DESCRIPTION
## Summary
- add an `apply_modifiers` helper to `StatsComponent` and expose `get_inverse_modifiers` / `revert_modifiers` while keeping `apply_stat_mod` as a compatibility wrapper
- switch `StatusSystem` to the new revert helper so status expiry rolls back passive changes through the component API
- refresh the designer and engineer manuals to point at the new modifier utilities

## Testing
- python tools/gdscript_parse_helper.py src *(fails: gdtoolkit missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d4506129ac8320a05005db9ffcd9e3