### PR TITLE
Fix StatsComponent parser errors and clean style warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .godot/*
 !.godot/global_script_class_cache.cfg
 /android/
+# Local Godot editor installation for automation harnesses
+/tools/godot4/
+/Godot_v*.zip

--- a/src/components/Skill.gd
+++ b/src/components/Skill.gd
@@ -15,7 +15,7 @@ const ULTEnums := preload("res://src/globals/ULTEnums.gd")
 @export var target_type: ULTEnums.TargetType = ULTEnums.TargetType.ENEMY
 @export var initiative_modifier: int = 0
 @export var area_of_effect: int = 0
-@export var range: int = 0
+@export var range_tiles: int = 0
 
 @export_group("Status Effect")
 ## If this skill applies a status effect, define it here. Leave blank for no effect.

--- a/src/components/StatsComponent.gd
+++ b/src/components/StatsComponent.gd
@@ -404,7 +404,7 @@ func get_inverse_modifiers(modifiers: Dictionary) -> Dictionary:
 
     var inverse: Dictionary = {}
     for key in modifiers.keys():
-        var value := modifiers[key]
+        var value: Variant = modifiers[key]
         if value == null:
             continue
 
@@ -426,24 +426,24 @@ func get_inverse_modifiers(modifiers: Dictionary) -> Dictionary:
                     var removal: Array[StringName] = []
                     if inverse.has("remove_status"):
                         removal = inverse["remove_status"]
-                    for status in value:
-                        removal.append(StringName(status))
+                    for status_name in value:
+                        removal.append(StringName(status_name))
                     inverse["remove_status"] = removal
             "traits_to_add":
                 if value is Array:
                     var traits_to_remove: Array[StringName] = []
                     if inverse.has("traits_to_remove"):
                         traits_to_remove = inverse["traits_to_remove"]
-                    for trait in value:
-                        traits_to_remove.append(StringName(trait))
+                    for trait_name in value:
+                        traits_to_remove.append(StringName(trait_name))
                     inverse["traits_to_remove"] = traits_to_remove
             "traits_to_remove":
                 if value is Array:
                     var traits_to_add: Array[StringName] = []
                     if inverse.has("traits_to_add"):
                         traits_to_add = inverse["traits_to_add"]
-                    for trait in value:
-                        traits_to_add.append(StringName(trait))
+                    for trait_name in value:
+                        traits_to_add.append(StringName(trait_name))
                     inverse["traits_to_add"] = traits_to_add
             _:
                 continue

--- a/src/core/EntityData.gd
+++ b/src/core/EntityData.gd
@@ -214,8 +214,8 @@ func ensure_runtime_entity_id(preferred_hint: StringName = StringName()) -> Stri
 ## instance. This is primarily used by Entity nodes that may briefly exist
 ## without an attached manifest but still require an id for debug tooling.
 static func generate_runtime_entity_id(preferred_hint: StringName = StringName()) -> StringName:
-        var seed: String = _derive_preferred_seed(String(preferred_hint))
-        return _claim_runtime_identifier(seed)
+        var seed_hint: String = _derive_preferred_seed(String(preferred_hint))
+        return _claim_runtime_identifier(seed_hint)
 
 ## Clears the runtime registry. World reset flows should call this so newly
 ## spawned entities can reclaim canonical ids like ``goblin_archer`` again.
@@ -242,10 +242,10 @@ static func _derive_preferred_seed(
         return "entity"
 
 static func _claim_runtime_identifier(raw_seed: String) -> StringName:
-        var seed := raw_seed.strip_edges()
-        if seed.is_empty():
-                seed = "entity"
-        var normalised: String = seed.to_snake_case()
+        var stripped_seed := raw_seed.strip_edges()
+        if stripped_seed.is_empty():
+                stripped_seed = "entity"
+        var normalised: String = stripped_seed.to_snake_case()
         if normalised.is_empty():
                 normalised = "entity"
 

--- a/src/systems/ValidationLoop.gd
+++ b/src/systems/ValidationLoop.gd
@@ -2,8 +2,6 @@ extends "res://src/systems/System.gd"
 class_name ValidationLoop
 
 const ULTEnums = preload("res://src/globals/ULTEnums.gd")
-const EntityData = preload("res://src/core/EntityData.gd")
-const StatsComponent = preload("res://src/components/StatsComponent.gd")
 
 func _physics_process(_delta: float) -> void:
     var entities = get_tree().get_nodes_in_group("entities")

--- a/tests/scripts/system_testbed/EntitySpawnerPanel.gd
+++ b/tests/scripts/system_testbed/EntitySpawnerPanel.gd
@@ -154,9 +154,9 @@ func _prepare_entity_data(template: EntityData) -> EntityData:
     if template == null:
         return null
     if template.has_method("duplicate_with_components"):
-        var duplicate: EntityData = template.duplicate_with_components()
-        if duplicate != null:
-            return duplicate
+        var cloned_manifest: EntityData = template.duplicate_with_components()
+        if cloned_manifest != null:
+            return cloned_manifest
 
     var fallback: EntityData = template.duplicate(true) as EntityData
     if fallback == null:

--- a/tests/scripts/system_testbed/StatusSystemValidator.gd
+++ b/tests/scripts/system_testbed/StatusSystemValidator.gd
@@ -176,7 +176,7 @@ func _validate_short_term_lifecycle(
     var stats: STATS_COMPONENT_SCRIPT = context.get("stats")
     var status_component: STATUS_COMPONENT_SCRIPT = context.get("status_component")
     var entity_data: ENTITY_DATA_SCRIPT = context.get("entity_data")
-    var entity: ENTITY_SCRIPT = context.get("entity")
+    var entity_ref: ENTITY_SCRIPT = context.get("entity")
 
     var effect := STATUS_FX_SCRIPT.new()
     effect.effect_name = SHORT_TERM_EFFECT_NAME
@@ -212,8 +212,8 @@ func _validate_short_term_lifecycle(
         errors.append("Expected one status_effect_applied payload but captured %d." % applied_events.size())
     else:
         var payload := applied_events[0]
-        if payload.get("entity_id") != entity.get_entity_id():
-            errors.append("status_effect_applied entity_id mismatch; expected %s." % String(entity.get_entity_id()))
+        if payload.get("entity_id") != entity_ref.get_entity_id():
+            errors.append("status_effect_applied entity_id mismatch; expected %s." % String(entity_ref.get_entity_id()))
         if payload.get("effect_name") != SHORT_TERM_EFFECT_NAME:
             errors.append("status_effect_applied effect_name mismatch; expected %s." % String(SHORT_TERM_EFFECT_NAME))
         if payload.get("duration") != SHORT_TERM_DURATION:
@@ -241,8 +241,8 @@ func _validate_short_term_lifecycle(
         errors.append("Expected one status_effect_ended payload after expiration but captured %d." % ended_events.size())
     else:
         var ended_payload := ended_events[0]
-        if ended_payload.get("entity_id") != entity.get_entity_id():
-            errors.append("status_effect_ended entity_id mismatch; expected %s." % String(entity.get_entity_id()))
+        if ended_payload.get("entity_id") != entity_ref.get_entity_id():
+            errors.append("status_effect_ended entity_id mismatch; expected %s." % String(entity_ref.get_entity_id()))
         if ended_payload.get("effect_name") != SHORT_TERM_EFFECT_NAME:
             errors.append("status_effect_ended effect_name mismatch; expected %s." % String(SHORT_TERM_EFFECT_NAME))
         if ended_payload.get("reason") != StringName("expired_turn"):
@@ -390,11 +390,11 @@ func _log_results(results: Array[Dictionary]) -> void:
     for result in results:
         if result.is_empty():
             continue
-        var name: String = result.get("name", "Unnamed validation")
+        var result_name: String = result.get("name", "Unnamed validation")
         var passed: bool = result.get("passed", false)
         var status_label := "PASS" if passed else "FAIL"
-        print("[StatusSystemValidator] %s - %s" % [status_label, name])
+        print("[StatusSystemValidator] %s - %s" % [status_label, result_name])
         if not passed:
             var errors: Array = result.get("errors", [])
             for error in errors:
-                push_warning("[StatusSystemValidator] %s: %s" % [name, error])
+                push_warning("[StatusSystemValidator] %s: %s" % [result_name, error])


### PR DESCRIPTION
## Summary
- annotate StatsComponent modifier iteration to avoid type inference failures and normalize loop variable naming to remove parser warnings
- rename the Skill range export, seed helpers in EntityData, and validation helpers that shadow built-ins or base properties
- drop ValidationLoop preloads that shadow global classes and tidy test utilities for clearer logging
- ignore the local Godot editor install artifacts used during automation setup

## Testing
- godot4 --headless --path . --check-only
- python tools/gdscript_parse_helper.py src/components src/core src/systems tests/scripts/system_testbed

------
https://chatgpt.com/codex/tasks/task_e_68d6d2afb4b8832092fd32f886d3d910