### PR TITLE
Fix EntityData components export typing for editor drag-and-drop

### DIFF
--- a/assets/entity_archetypes/GoblinArcher_EntityData.tres
+++ b/assets/entity_archetypes/GoblinArcher_EntityData.tres
@@ -9,6 +9,6 @@ entity_id = "goblin_archer"
 display_name = "Goblin Archer"
 entity_type = 2
 archetype_id = "GoblinArcher"
-components = Dictionary[StringName, Resource]({
+components = Dictionary[StringName, Component]({
 &"stats": ExtResource("2")
 })

--- a/assets/entity_archetypes/SkeletonWarrior_EntityData.tres
+++ b/assets/entity_archetypes/SkeletonWarrior_EntityData.tres
@@ -9,6 +9,6 @@ entity_id = "skeleton_warrior"
 display_name = "Skeleton Warrior"
 entity_type = 2
 archetype_id = "SkeletonWarrior"
-components = Dictionary[StringName, Resource]({
+components = Dictionary[StringName, Component]({
 &"stats": ExtResource("2")
 })

--- a/src/core/EntityData.gd
+++ b/src/core/EntityData.gd
@@ -34,7 +34,7 @@ var _invalid_component_warnings: Dictionary[String, bool] = {}
 ## all attached Component Resources, keyed by a canonical StringName identifier
 ## (e.g., ComponentKeys.STATS).
 ## Keys MUST correspond to the constants defined in ULTEnums.gd (e.g., ComponentKeys.STATS).
-var _components: Dictionary[StringName, Resource] = {}
+var _components: Dictionary[StringName, Component] = {}
 
 ## Exposed manifest of component resources keyed by canonical identifiers.
 ##
@@ -44,7 +44,7 @@ var _components: Dictionary[StringName, Resource] = {}
 ## `StringName` for stable lookups while tolerating legacy manifest data. The
 ## getter exposes the live manifest so existing editor tooling and tests that
 ## expect direct dictionary access continue to function.
-@export var components := {}:
+@export var components: Dictionary[StringName, Component] = {}:
     set(value):
         _invalid_component_warnings.clear()
         _components = _sanitize_component_manifest(value)
@@ -53,7 +53,7 @@ var _components: Dictionary[StringName, Resource] = {}
 
 ## Registers or replaces a component using a canonical ComponentKeys identifier.
 ## Converts arbitrary string inputs to StringName before storage to ensure stable lookups.
-func add_component(key: Variant, component: Resource) -> void:
+func add_component(key: Variant, component: Component) -> void:
     assert(component != null, "EntityData.add_component requires a Component instance.")
     assert(
         _is_component_resource(component),
@@ -71,7 +71,7 @@ func add_component(key: Variant, component: Resource) -> void:
 
 ## Retrieves a component reference by its canonical key.
 ## Returns null if the key is not registered on this entity.
-func get_component(key: Variant) -> Resource:
+func get_component(key: Variant) -> Component:
     var normalized_key: StringName = _normalize_component_key(key)
     if not ULTEnums.is_valid_component_key(normalized_key):
         return null
@@ -100,7 +100,7 @@ func has_component(key: Variant) -> bool:
 
 ## Removes a component from the manifest and returns the detached resource.
 ## Returns null when no component was registered for the provided key.
-func remove_component(key: Variant) -> Resource:
+func remove_component(key: Variant) -> Component:
     var normalized_key: StringName = _normalize_component_key(key)
     if not ULTEnums.is_valid_component_key(normalized_key):
         return null
@@ -115,8 +115,8 @@ func remove_component(key: Variant) -> Resource:
 
 ## Produces a shallow copy of the component manifest for safe iteration.
 ## External systems must treat the returned dictionary as read-only metadata.
-func list_components() -> Dictionary[StringName, Resource]:
-    var manifest: Dictionary[StringName, Resource] = {}
+func list_components() -> Dictionary[StringName, Component]:
+    var manifest: Dictionary[StringName, Component] = {}
     for key in _components.keys():
         var normalized: StringName = _normalize_component_key(key)
         if not ULTEnums.is_valid_component_key(normalized):
@@ -144,8 +144,8 @@ func _locate_component_entry(normalized_key: StringName) -> Dictionary:
         entry["key"] = normalized_key
     return entry
 
-func _sanitize_component_manifest(raw_value: Variant) -> Dictionary[StringName, Resource]:
-    var sanitized: Dictionary[StringName, Resource] = {}
+func _sanitize_component_manifest(raw_value: Variant) -> Dictionary[StringName, Component]:
+    var sanitized: Dictionary[StringName, Component] = {}
     if raw_value == null:
         return sanitized
     if not (raw_value is Dictionary):

--- a/tests/scripts/system_testbed/EntitySpawnerPanel.gd
+++ b/tests/scripts/system_testbed/EntitySpawnerPanel.gd
@@ -162,12 +162,12 @@ func _prepare_entity_data(template: EntityData) -> EntityData:
     if fallback == null:
         return null
 
-    var manifest: Dictionary[StringName, Resource] = fallback.list_components()
+    var manifest: Dictionary[StringName, Component] = fallback.list_components()
     for component_key in manifest.keys():
-        var component: Resource = manifest.get(component_key)
+        var component: Component = manifest.get(component_key)
         if component == null:
             continue
-        var component_copy: Resource = component.duplicate(true)
+        var component_copy: Component = component.duplicate(true) as Component
         if component_copy == null:
             continue
         fallback.add_component(component_key, component_copy)

--- a/tests/test_assets/TestDum2.tres
+++ b/tests/test_assets/TestDum2.tres
@@ -9,7 +9,7 @@ entity_id = ""
 display_name = ""
 entity_type = 1
 archetype_id = ""
-components = Dictionary[StringName, Resource]({
+components = Dictionary[StringName, Component]({
 &"stats": ExtResource("1_vjp57")
 })
 metadata/_custom_type_script = "uid://dkwlkfpl03j5t"


### PR DESCRIPTION
## Summary
- type the EntityData.components export as Dictionary[StringName, Component] so the inspector exposes component slots for drag-and-drop authoring
- update system testbed duplication helpers and existing entity manifests to align with the stronger component typing

## Testing
- godot4 --headless --path . --quit

------
https://chatgpt.com/codex/tasks/task_e_68d6da2988b8832082916231d0365be2