### PR TITLE
Fix EntityData component inspector assignment

### DIFF
--- a/src/core/EntityData.gd
+++ b/src/core/EntityData.gd
@@ -38,13 +38,13 @@ var _components: Dictionary[StringName, Component] = {}
 
 ## Exposed manifest of component resources keyed by canonical identifiers.
 ##
-## The exported dictionary is now strongly typed so the Inspector knows each
-## value expects a Component resource, enabling drag-and-drop authoring from the
-## FileSystem dock. The internal `_components` cache still normalises keys to
-## `StringName` for stable lookups while tolerating legacy manifest data. The
-## getter exposes the live manifest so existing editor tooling and tests that
-## expect direct dictionary access continue to function.
-@export var components: Dictionary[StringName, Component] = {}:
+## The Inspector currently serialises dictionary edits without generic type
+## metadata, so we export this property as an untyped ``Dictionary`` and perform
+## validation in the setter. The internal `_components` cache still normalises
+## keys to `StringName` for stable lookups while tolerating legacy manifest data.
+## The getter exposes the live manifest so existing editor tooling and tests
+## that expect direct dictionary access continue to function.
+@export var components := {}:
     set(value):
         _invalid_component_warnings.clear()
         _components = _sanitize_component_manifest(value)


### PR DESCRIPTION
## Summary
- export the EntityData.components dictionary without generics so the Godot inspector accepts drag-and-drop resources
- document the setter-based validation that preserves type safety while normalising the internal component cache

## Testing
- `godot4 --headless --path . --script res://tools/tmp_assign.gd`

------
https://chatgpt.com/codex/tasks/task_e_68d6e196c7848320aff70cf7af4619c9