### PR TITLE
Implement job bonuses and editor-friendly job data

### DIFF
--- a/assets/skills/ArcaneBoltSkill.tres
+++ b/assets/skills/ArcaneBoltSkill.tres
@@ -1,0 +1,23 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+[ext_resource path="res://src/components/Skill.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource(1)
+skill_name = "arcane_bolt"
+description = "Launches a focused bolt of energy at a single target."
+category = 1
+rarity = 0
+ap_cost = 2
+damage = 18
+target_type = 1
+initiative_modifier = 0
+area_of_effect = 0
+range_tiles = 6
+status_effect_to_apply = ""
+status_effect_duration = 3
+status_effect_is_long_term = false
+status_effect_chance = 1.0
+base_traits = []
+weapon_requirement = 0
+base_actions = []
+upgrades = {}

--- a/assets/skills/ManaBarrierSkill.tres
+++ b/assets/skills/ManaBarrierSkill.tres
@@ -1,0 +1,23 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+[ext_resource path="res://src/components/Skill.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource(1)
+skill_name = "mana_barrier"
+description = "Raises a protective barrier that absorbs incoming attacks for one round."
+category = 2
+rarity = 1
+ap_cost = 3
+damage = 0
+target_type = 0
+initiative_modifier = 0
+area_of_effect = 0
+range_tiles = 0
+status_effect_to_apply = "barriered"
+status_effect_duration = 1
+status_effect_is_long_term = false
+status_effect_chance = 1.0
+base_traits = []
+weapon_requirement = 0
+base_actions = []
+upgrades = {}

--- a/devdocs/Designers/StatsComponentManual.md
+++ b/devdocs/Designers/StatsComponentManual.md
@@ -12,7 +12,9 @@ Each section groups related properties. "Common range" records the values most b
 
 | Property | Type | Description | Common range & notes |
 | --- | --- | --- | --- |
-| `job_component` | `JobComponent` | Optional reference to a modular job overlay that injects profession metadata, stat bonuses, skills, and traits on top of the baseline stats.【F:src/components/StatsComponent.gd†L8-L12】【F:src/components/JobComponent.gd†L1-L40】 | Leave unset for generic civilians. Starter archetypes normally bind a `JobComponent` with a single primary job; late-game entities may expose alternates for generators to roll between. |
+| `job_component` | `JobComponent` | Optional reference to a modular job overlay that injects profession metadata, stat bonuses, skills, and traits on top of the baseline stats.【F:src/components/StatsComponent.gd†L8-L12】【F:src/components/JobComponent.gd†L1-L55】 | Leave unset for generic civilians. Starter archetypes normally bind a `JobComponent` with a single primary job; late-game entities may expose alternates for generators to roll between. When a `JobComponent` is assigned the stats component now applies additive stat and training bonuses immediately and merges any job-supplied trait resources, keeping the effective values synchronized as designers tweak the job resource.【F:src/components/StatsComponent.gd†L8-L189】 |
+
+Job resources expose designer-friendly arrays so profession data can be composed without touching dictionaries. Use the `stat_bonuses` and `training_bonuses` lists to add any number of `JobStatBonus` or `JobTrainingBonus` entries, each pairing a StatsComponent property with an additive modifier. `starting_skills` accepts direct references to `Skill` resources, and `starting_traits` links `Trait` resources that should be injected when the job is active.【F:src/jobs/Job.gd†L1-L88】【F:src/jobs/MageJob.gd†L1-L63】
 
 ## Vital resources and tactical economy
 

--- a/src/components/JobComponent.gd
+++ b/src/components/JobComponent.gd
@@ -24,6 +24,23 @@ func get_primary_job_id() -> StringName:
         return StringName("")
     return job.job_id
 
+func get_primary_job() -> Resource:
+    return _as_job(primary_job)
+
+func list_jobs() -> Array[Resource]:
+    var jobs: Array[Resource] = []
+    var primary := _as_job(primary_job)
+    if primary != null:
+        jobs.append(primary)
+    for entry in alternate_jobs:
+        var job := _as_job(entry)
+        if job == null:
+            continue
+        if jobs.has(job):
+            continue
+        jobs.append(job)
+    return jobs
+
 func list_job_ids() -> PackedStringArray:
     var ids: PackedStringArray = []
     var primary = _as_job(primary_job)

--- a/src/jobs/Job.gd
+++ b/src/jobs/Job.gd
@@ -1,6 +1,11 @@
 extends Resource
 class_name Job
 
+const JobStatBonus := preload("res://src/jobs/JobStatBonus.gd")
+const JobTrainingBonus := preload("res://src/jobs/JobTrainingBonus.gd")
+const Trait := preload("res://src/components/Trait.gd")
+const Skill := preload("res://src/components/Skill.gd")
+
 ## Data-only resource describing a modular profession or role overlay.
 ## Jobs augment baseline stats with additional bonuses, loadouts, and
 ## metadata so the same StatsComponent resource can support multiple
@@ -13,27 +18,38 @@ class_name Job
 
 @export_group("Stat Bonuses")
 ## Additive modifiers applied when the job is attached to a StatsComponent.
-## Keys should match exported property names on StatsComponent (e.g., "strength").
-@export var stat_bonuses: Dictionary[StringName, int] = {}
+@export var stat_bonuses: Array[JobStatBonus] = []
 
 @export_group("Training Bonuses")
 ## Additive modifiers to training proficiencies identified by StringName.
-@export var training_bonuses: Dictionary[StringName, int] = {}
+@export var training_bonuses: Array[JobTrainingBonus] = []
 
 @export_group("Skill Loadout")
-## Skill identifiers granted when the job is assigned.
-@export var starting_skills: Array[StringName] = []
+## Skill resources granted when the job is assigned.
+@export var starting_skills: Array[Skill] = []
 
 ## Mapping of skill ids to option arrays unlocked by the job (e.g., tree choices).
 @export var skill_options: Dictionary[StringName, Array] = {}
 
 @export_group("Traits")
-## Trait identifiers always granted by the job.
-@export var starting_traits: Array[StringName] = []
+## Trait resources always granted by the job.
+@export var starting_traits: Array[Trait] = []
 
 @export_group("Formula Overrides")
 ## Arbitrary override tokens consumed by systems (e.g., damage formulas).
 @export var formula_overrides: Dictionary[StringName, Variant] = {}
+
+func get_stat_bonuses() -> Array[JobStatBonus]:
+    return stat_bonuses.duplicate()
+
+func get_training_bonuses() -> Array[JobTrainingBonus]:
+    return training_bonuses.duplicate()
+
+func get_starting_skills() -> Array[Skill]:
+    return starting_skills.duplicate()
+
+func get_starting_traits() -> Array[Trait]:
+    return starting_traits.duplicate()
 
 ## Returns a stable snapshot suitable for serialization or tests.
 func to_dictionary() -> Dictionary:
@@ -42,14 +58,53 @@ func to_dictionary() -> Dictionary:
         var options: Array = skill_options[skill_id]
         options_snapshot[skill_id] = options.duplicate()
 
+    var stat_snapshot: Array[Dictionary] = []
+    for bonus in stat_bonuses:
+        if bonus == null:
+            continue
+        stat_snapshot.append(bonus.to_dictionary())
+
+    var training_snapshot: Array[Dictionary] = []
+    for bonus in training_bonuses:
+        if bonus == null:
+            continue
+        training_snapshot.append(bonus.to_dictionary())
+
+    var skill_snapshot: Array[Dictionary] = []
+    for skill in starting_skills:
+        if skill == null:
+            continue
+        skill_snapshot.append(_skill_to_dictionary(skill))
+
+    var trait_snapshot: Array[Dictionary] = []
+    for trait_resource in starting_traits:
+        if trait_resource == null:
+            continue
+        trait_snapshot.append(_trait_to_dictionary(trait_resource))
+
     return {
         "job_id": job_id,
         "job_title": job_title,
         "job_pool_tags": job_pool_tags.duplicate(),
-        "stat_bonuses": stat_bonuses.duplicate(true),
-        "training_bonuses": training_bonuses.duplicate(true),
-        "starting_skills": starting_skills.duplicate(),
+        "stat_bonuses": stat_snapshot,
+        "training_bonuses": training_snapshot,
+        "starting_skills": skill_snapshot,
         "skill_options": options_snapshot,
-        "starting_traits": starting_traits.duplicate(),
+        "starting_traits": trait_snapshot,
         "formula_overrides": formula_overrides.duplicate(true),
+    }
+
+func _skill_to_dictionary(skill: Skill) -> Dictionary:
+    return {
+        "resource_path": skill.resource_path,
+        "skill_name": skill.skill_name,
+        "category": skill.category,
+        "rarity": skill.rarity,
+    }
+
+func _trait_to_dictionary(trait_resource: Trait) -> Dictionary:
+    return {
+        "resource_path": trait_resource.resource_path,
+        "trait_id": trait_resource.trait_id,
+        "display_name": trait_resource.display_name,
     }

--- a/src/jobs/JobStatBonus.gd
+++ b/src/jobs/JobStatBonus.gd
@@ -1,0 +1,34 @@
+extends Resource
+class_name JobStatBonus
+
+## Data entry describing a single StatsComponent property bonus granted by a job.
+## Designers pick the exported ``stat_property`` from the StatsComponent property
+## list and provide a numeric ``amount`` that will be added on top of the
+## baseline value when the job is assigned.
+
+var _stat_property: StringName = StringName("")
+var _amount: int = 0
+
+@export var stat_property: StringName:
+    get:
+        return _stat_property
+    set(value):
+        if _stat_property == value:
+            return
+        _stat_property = value
+        emit_changed()
+
+@export var amount: int:
+    get:
+        return _amount
+    set(value):
+        if _amount == value:
+            return
+        _amount = value
+        emit_changed()
+
+func to_dictionary() -> Dictionary:
+    return {
+        "stat_property": stat_property,
+        "amount": amount,
+    }

--- a/src/jobs/JobTrainingBonus.gd
+++ b/src/jobs/JobTrainingBonus.gd
@@ -1,0 +1,34 @@
+extends Resource
+class_name JobTrainingBonus
+
+## Data entry describing a training proficiency bonus supplied by a job.
+## ``training_property`` should map to an exported training stat on
+## ``StatsComponent`` such as ``athletics`` or ``lore``. ``amount`` is the
+## additive modifier applied when the job is active.
+
+var _training_property: StringName = StringName("")
+var _amount: int = 0
+
+@export var training_property: StringName:
+    get:
+        return _training_property
+    set(value):
+        if _training_property == value:
+            return
+        _training_property = value
+        emit_changed()
+
+@export var amount: int:
+    get:
+        return _amount
+    set(value):
+        if _amount == value:
+            return
+        _amount = value
+        emit_changed()
+
+func to_dictionary() -> Dictionary:
+    return {
+        "training_property": training_property,
+        "amount": amount,
+    }

--- a/src/jobs/MageJob.gd
+++ b/src/jobs/MageJob.gd
@@ -3,24 +3,72 @@ class_name MageJob
 
 ## Sample job demonstrating how to preconfigure a magic-focused loadout.
 
+const ARCANE_BOLT_SKILL_PATH := "res://assets/skills/ArcaneBoltSkill.tres"
+const MANA_BARRIER_SKILL_PATH := "res://assets/skills/ManaBarrierSkill.tres"
+const FIRE_ATTUNED_TRAIT_PATH := "res://assets/traits/FireAttunedTrait.tres"
+const QUICK_TRAIT_PATH := "res://assets/traits/QuickTrait.tres"
+
 func _init() -> void:
     job_id = StringName("mage")
     job_title = "Battle Mage"
     job_pool_tags = [StringName("magic"), StringName("starter")]
-    stat_bonuses = {
-        StringName("max_energy"): 30,
-        StringName("intelligence"): 4,
-        StringName("wisdom"): 2,
-    }
-    training_bonuses = {
-        StringName("lore"): 3,
-        StringName("technical"): 1,
-    }
-    starting_skills = [StringName("arcane_bolt"), StringName("mana_barrier")]
+    var energy_bonus := JobStatBonus.new()
+    energy_bonus.stat_property = StringName("max_energy")
+    energy_bonus.amount = 30
+
+    var intelligence_bonus := JobStatBonus.new()
+    intelligence_bonus.stat_property = StringName("intelligence")
+    intelligence_bonus.amount = 4
+
+    var wisdom_bonus := JobStatBonus.new()
+    wisdom_bonus.stat_property = StringName("wisdom")
+    wisdom_bonus.amount = 2
+
+    stat_bonuses = [energy_bonus, intelligence_bonus, wisdom_bonus]
+
+    var lore_bonus := JobTrainingBonus.new()
+    lore_bonus.training_property = StringName("lore")
+    lore_bonus.amount = 3
+
+    var technical_bonus := JobTrainingBonus.new()
+    technical_bonus.training_property = StringName("technical")
+    technical_bonus.amount = 1
+
+    training_bonuses = [lore_bonus, technical_bonus]
+
+    starting_skills = _load_skills([
+        ARCANE_BOLT_SKILL_PATH,
+        MANA_BARRIER_SKILL_PATH,
+    ])
     skill_options = {
         StringName("arcane_bolt"): [StringName("focus_burst"), StringName("piercing_wave")],
     }
-    starting_traits = [StringName("arcane_attuned"), StringName("scholar")]
+    starting_traits = _load_traits([
+        FIRE_ATTUNED_TRAIT_PATH,
+        QUICK_TRAIT_PATH,
+    ])
     formula_overrides = {
         StringName("energy_regen_formula"): StringName("mage_channel"),
     }
+
+
+func _load_skills(paths: Array[String]) -> Array[Skill]:
+    var result: Array[Skill] = []
+    for path in paths:
+        var resource := load(path)
+        if resource == null:
+            continue
+        if resource is Skill:
+            result.append(resource)
+    return result
+
+
+func _load_traits(paths: Array[String]) -> Array[Trait]:
+    var result: Array[Trait] = []
+    for path in paths:
+        var resource := load(path)
+        if resource == null:
+            continue
+        if resource is Trait:
+            result.append(resource)
+    return result

--- a/tests/job_system_test.gd
+++ b/tests/job_system_test.gd
@@ -1,0 +1,54 @@
+extends SceneTree
+
+const StatsComponent := preload("res://src/components/StatsComponent.gd")
+const Job := preload("res://src/jobs/Job.gd")
+const JobStatBonus := preload("res://src/jobs/JobStatBonus.gd")
+const JobTrainingBonus := preload("res://src/jobs/JobTrainingBonus.gd")
+const Trait := preload("res://src/components/Trait.gd")
+const JobComponent := preload("res://src/components/JobComponent.gd")
+
+func _init() -> void:
+    _run_tests()
+    quit()
+
+func _run_tests() -> void:
+    var stats := StatsComponent.new()
+    stats.strength = 2
+    stats.athletics = 1
+
+    var job := Job.new()
+    job.job_id = StringName("tester")
+
+    var stat_bonus := JobStatBonus.new()
+    stat_bonus.stat_property = StringName("strength")
+    stat_bonus.amount = 3
+    job.stat_bonuses = [stat_bonus]
+
+    var training_bonus := JobTrainingBonus.new()
+    training_bonus.training_property = StringName("athletics")
+    training_bonus.amount = 4
+    job.training_bonuses = [training_bonus]
+
+    var trait_resource := Trait.new()
+    trait_resource.trait_id = "test_trait"
+    job.starting_traits = [trait_resource]
+
+    var component := JobComponent.new()
+    component.primary_job = job
+
+    stats.job_component = component
+
+    assert(stats.strength == 5, "Strength should include job bonus")
+    assert(stats.athletics == 5, "Athletics should include job training bonus")
+    assert(StringName("test_trait") in stats.traits, "Trait from job should be applied")
+    assert(stat_bonus.changed.is_connected(Callable(stats, "_on_job_resource_changed")), "Stats component should listen for job stat changes")
+
+    stat_bonus.amount = 5
+    assert(stats.strength == 7, "Strength should refresh after stat bonus update")
+
+    stats.job_component = null
+    assert(stats.strength == 2, "Strength should revert when job removed")
+    assert(stats.athletics == 1, "Training should revert when job removed")
+    assert(not (StringName("test_trait") in stats.traits), "Job trait should be removed when job cleared")
+
+    print("Job system tests passed.")


### PR DESCRIPTION
## Summary
- make StatsComponent automatically apply and refresh job-driven stat, training, and trait bonuses by tracking JobComponent and subresource changes
- replace Job dictionaries with editor-friendly JobStatBonus/JobTrainingBonus resources and hook MageJob into concrete Skill/Trait assets
- document the new workflow for designers and add a headless job system regression test along with sample skill resources

## Testing
- godot4 --headless --path . --script res://tests/job_system_test.gd

------
https://chatgpt.com/codex/tasks/task_e_68d70be249f883209003d9178029028a