### PR TITLE
Refine job bonus inspectors and document job system

### DIFF
--- a/devdocs/JobSystemREADME.md
+++ b/devdocs/JobSystemREADME.md
@@ -1,0 +1,26 @@
+# Job System Overview
+
+The job system layers modular profession data on top of a character's baseline `StatsComponent`. Each entity that supports jobs references a `JobComponent` resource, which stores a primary job and optional alternates. When a `StatsComponent` receives a job component it immediately resolves the primary job, applies any stat and training bonuses, merges the granted traits and skills, and subscribes to change notifications so edits in the Inspector propagate live during play.
+
+## Data resources
+
+- **`JobComponent`** – Bridges the stats resource to modular job definitions. Designers assign a `primary_job` and optional `alternate_jobs` so generators can roll substitutes without touching baseline stats.【F:src/components/JobComponent.gd†L1-L55】
+- **`Job`** – Authorable profession resource that captures identity, stat bonuses, training bonuses, granted skills, granted traits, and formula overrides. Utility methods return defensive copies for serialization or runtime inspection.【F:src/jobs/Job.gd†L1-L88】
+- **`JobStatBonus`** – Helper resource for additive stat adjustments. The Inspector now exposes a curated dropdown of core `StatsComponent` fields (Health, Energy, AP, Body, Mind, STR, AGL, SPD, INT, WIS, CHR, plus their max/pool variants) so designers only edit the numeric amount. Custom string names are still accepted for edge cases.【F:src/jobs/JobStatBonus.gd†L1-L83】
+- **`JobTrainingBonus`** – Helper resource for training adjustments. Designers select the relevant training (Athletics, Combat, Thievery, Diplomacy, Lore, or Technical) and enter the additive amount.【F:src/jobs/JobTrainingBonus.gd†L1-L73】
+
+## Runtime flow
+
+`StatsComponent` loads the job component script on demand, validates that resources actually extend `Job`/`JobComponent`, and applies bonuses when the job attachment changes. Stat and training modifiers call `_get_numeric_property()` to ensure the named property exists; any unknown keys trigger a warning so data errors surface immediately.【F:src/components/StatsComponent.gd†L259-L316】 The component tracks applied deltas in `_applied_job_snapshot`, allowing `_remove_job_bonuses()` to restore baseline values when the job changes or the component is cleared.【F:src/components/StatsComponent.gd†L318-L374】
+
+Traits and skills added by the job follow the same lifecycle: they are injected during `_apply_job_bonuses()`, recorded in the snapshot, and removed when the job is detached. The stats resource also subscribes to the job's `changed` signal, so edits to the job resource or its subresources re-run `_refresh_job_bonuses()` automatically.【F:src/components/StatsComponent.gd†L300-L373】
+
+## Inspector workflow
+
+1. Create or open a `Job` resource under `res://src/jobs/` or your content directory.
+2. In the **Stat Bonuses** section, add entries as needed. Use the dropdown to pick the target stat; leave the amount at `0` for no adjustment or raise/lower to apply bonuses or penalties. The field accepts manual text if you must reference a bespoke `StatsComponent` property.
+3. Populate the **Training Bonuses** array with training modifiers. Each entry targets one of the canonical proficiencies exposed by `StatsComponent`.
+4. Assign `starting_traits`, `starting_skills`, and `formula_overrides` as required by your design.
+5. Attach the job to an entity by creating a `JobComponent`, assigning the job resource to `primary_job`, and linking the job component to the entity's `StatsComponent`.
+
+At runtime the `StatsComponent` reflects these bonuses immediately. You can verify changes in the remote inspector or via the `DebugSystem`, which reports job-adjusted stats every frame in the sprint validation scene.【F:tests/Sprint1_Validation.tscn†L3-L14】【F:src/systems/DebugSystem.gd†L18-L33】 Edits made while the game is running propagate because the stats resource monitors the job resource and each bonus subresource's `changed` signal.【F:src/components/StatsComponent.gd†L259-L383】

--- a/src/jobs/JobStatBonus.gd
+++ b/src/jobs/JobStatBonus.gd
@@ -2,20 +2,56 @@ extends Resource
 class_name JobStatBonus
 
 ## Data entry describing a single StatsComponent property bonus granted by a job.
-## Designers pick the exported ``stat_property`` from the StatsComponent property
-## list and provide a numeric ``amount`` that will be added on top of the
-## baseline value when the job is assigned.
+## Designers pick the exported ``stat_property`` from a curated list of common
+## StatsComponent fields and provide a numeric ``amount`` that will be added on
+## top of the baseline value when the job is assigned.
+
+const STAT_PROPERTY_HINT_STRING := \
+        "Health:health,Max Health:max_health,Energy:energy,Max Energy:max_energy," + \
+        "AP:action_points,Max AP:max_action_points,Body:body_pool_fixed,Body Pool Relative:body_pool_relative," + \
+        "Mind:mind_pool_fixed,Mind Pool Relative:mind_pool_relative,STR:strength,AGL:agility,SPD:speed," + \
+        "INT:intelligence,WIS:wisdom,CHR:charisma"
+
+const STAT_PROPERTY_LOOKUP := {
+    "health": StringName("health"),
+    "max_health": StringName("max_health"),
+    "energy": StringName("energy"),
+    "max_energy": StringName("max_energy"),
+    "ap": StringName("action_points"),
+    "action_points": StringName("action_points"),
+    "max ap": StringName("max_action_points"),
+    "max_action_points": StringName("max_action_points"),
+    "body": StringName("body_pool_fixed"),
+    "body_pool_fixed": StringName("body_pool_fixed"),
+    "body_pool_relative": StringName("body_pool_relative"),
+    "mind": StringName("mind_pool_fixed"),
+    "mind_pool_fixed": StringName("mind_pool_fixed"),
+    "mind_pool_relative": StringName("mind_pool_relative"),
+    "str": StringName("strength"),
+    "strength": StringName("strength"),
+    "agl": StringName("agility"),
+    "agility": StringName("agility"),
+    "spd": StringName("speed"),
+    "speed": StringName("speed"),
+    "int": StringName("intelligence"),
+    "intelligence": StringName("intelligence"),
+    "wis": StringName("wisdom"),
+    "wisdom": StringName("wisdom"),
+    "chr": StringName("charisma"),
+    "charisma": StringName("charisma"),
+}
 
 var _stat_property: StringName = StringName("")
 var _amount: int = 0
 
-@export var stat_property: StringName:
+@export_custom(PropertyHint.ENUM_SUGGESTION, STAT_PROPERTY_HINT_STRING) var stat_property: StringName:
     get:
         return _stat_property
     set(value):
-        if _stat_property == value:
+        var resolved := _resolve_stat_property(value)
+        if _stat_property == resolved:
             return
-        _stat_property = value
+        _stat_property = resolved
         emit_changed()
 
 @export var amount: int:
@@ -32,3 +68,22 @@ func to_dictionary() -> Dictionary:
         "stat_property": stat_property,
         "amount": amount,
     }
+
+func _resolve_stat_property(value: Variant) -> StringName:
+    if value is StringName:
+        if value == StringName(""):
+            return value
+        return _lookup_stat_property(String(value))
+    if value is String:
+        if value.strip_edges() == "":
+            return StringName("")
+        return _lookup_stat_property(value)
+    return _stat_property
+
+func _lookup_stat_property(value: String) -> StringName:
+    var normalized := value.strip_edges().to_lower()
+    if normalized == "":
+        return StringName("")
+    if STAT_PROPERTY_LOOKUP.has(normalized):
+        return STAT_PROPERTY_LOOKUP[normalized]
+    return StringName(value.strip_edges())

--- a/src/jobs/JobTrainingBonus.gd
+++ b/src/jobs/JobTrainingBonus.gd
@@ -2,20 +2,35 @@ extends Resource
 class_name JobTrainingBonus
 
 ## Data entry describing a training proficiency bonus supplied by a job.
-## ``training_property`` should map to an exported training stat on
-## ``StatsComponent`` such as ``athletics`` or ``lore``. ``amount`` is the
-## additive modifier applied when the job is active.
+## ``training_property`` maps to an exported training stat on ``StatsComponent``
+## such as ``athletics`` or ``lore``. ``amount`` is the additive modifier applied
+## when the job is active.
+
+const TRAINING_PROPERTY_HINT_STRING := \
+        "Athletics:athletics,Combat:combat_training,Thievery:thievery,Diplomacy:diplomacy," + \
+        "Lore:lore,Technical:technical"
+
+const TRAINING_PROPERTY_LOOKUP := {
+    "athletics": StringName("athletics"),
+    "combat": StringName("combat_training"),
+    "combat_training": StringName("combat_training"),
+    "thievery": StringName("thievery"),
+    "diplomacy": StringName("diplomacy"),
+    "lore": StringName("lore"),
+    "technical": StringName("technical"),
+}
 
 var _training_property: StringName = StringName("")
 var _amount: int = 0
 
-@export var training_property: StringName:
+@export_custom(PropertyHint.ENUM_SUGGESTION, TRAINING_PROPERTY_HINT_STRING) var training_property: StringName:
     get:
         return _training_property
     set(value):
-        if _training_property == value:
+        var resolved := _resolve_training_property(value)
+        if _training_property == resolved:
             return
-        _training_property = value
+        _training_property = resolved
         emit_changed()
 
 @export var amount: int:
@@ -32,3 +47,22 @@ func to_dictionary() -> Dictionary:
         "training_property": training_property,
         "amount": amount,
     }
+
+func _resolve_training_property(value: Variant) -> StringName:
+    if value is StringName:
+        if value == StringName(""):
+            return value
+        return _lookup_training_property(String(value))
+    if value is String:
+        if value.strip_edges() == "":
+            return StringName("")
+        return _lookup_training_property(value)
+    return _training_property
+
+func _lookup_training_property(value: String) -> StringName:
+    var normalized := value.strip_edges().to_lower()
+    if normalized == "":
+        return StringName("")
+    if TRAINING_PROPERTY_LOOKUP.has(normalized):
+        return TRAINING_PROPERTY_LOOKUP[normalized]
+    return StringName(value.strip_edges())


### PR DESCRIPTION
## Summary
- add curated inspector hints to `JobStatBonus` and `JobTrainingBonus` so designers choose from canonical StatsComponent fields while preserving manual overrides
- normalize incoming stat/training identifiers to prevent typos and keep job bonuses reactive to inspector changes
- document the job system pipeline and authoring workflow in `devdocs/JobSystemREADME.md`

## Testing
- not run (godot4 executable is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d717bd4a808320853ae7c16cfd1bf0