### PR TITLE
Add combat runtime data structures

### DIFF
--- a/src/components/CombatRuntimeComponent.gd
+++ b/src/components/CombatRuntimeComponent.gd
@@ -1,0 +1,52 @@
+extends "res://src/core/Component.gd"
+class_name CombatRuntimeComponent
+
+## Runtime combat state for a single entity. Tracks initiative roll bonuses and
+## temporary modifiers applied by statuses or abilities so combat systems can
+## reconstruct the current turn order without querying scene nodes.
+
+## Baseline initiative bonus applied each time the entity enters combat.
+@export var base_initiative_bonus: int = 0
+
+## Initiative score for the current encounter after modifiers have been applied.
+@export var current_initiative: int = 0
+
+## Active initiative modifiers awaiting expiration. Each entry stores:
+## { "amount": int, "remaining_turns": int, "source_id": StringName }
+@export var initiative_modifiers: Array[Dictionary] = []
+
+## Resets transient combat state when starting a new encounter. Clears all
+## modifiers and restores the current initiative to the base bonus value.
+func reset_for_new_encounter() -> void:
+    initiative_modifiers.clear()
+    current_initiative = base_initiative_bonus
+
+## Applies a temporary modifier to the initiative score for a fixed duration.
+## The modifier immediately affects the current initiative total.
+func apply_initiative_modifier(amount: int, duration: int, source: StringName) -> void:
+    var modifier := {
+        "amount": amount,
+        "remaining_turns": max(duration, 0),
+        "source_id": source,
+    }
+    initiative_modifiers.append(modifier)
+    current_initiative += amount
+
+## Advances modifier timers by one turn. Any modifier whose remaining duration
+## reaches zero is removed and its amount returned as part of the net bonus
+## stripped from the entity. The current initiative is reduced by the total.
+func tick_initiative_modifiers() -> int:
+    var expired_total := 0
+    var active_modifiers: Array[Dictionary] = []
+    for modifier in initiative_modifiers:
+        var remaining: int = int(modifier.get("remaining_turns", 0))
+        remaining -= 1
+        modifier["remaining_turns"] = remaining
+        if remaining > 0:
+            active_modifiers.append(modifier)
+        else:
+            expired_total += int(modifier.get("amount", 0))
+    initiative_modifiers = active_modifiers
+    if expired_total != 0:
+        current_initiative -= expired_total
+    return expired_total

--- a/src/core/CombatEncounterState.gd
+++ b/src/core/CombatEncounterState.gd
@@ -1,0 +1,67 @@
+extends Resource
+class_name CombatEncounterState
+
+## Resource describing the state of a tactical combat encounter. Systems can
+## persist turn order, participants, and bookkeeping counters without relying on
+## scene tree nodes. Designed for save/load serialisation and deterministic tests.
+
+## Current round index starting at zero for pre-roll bookkeeping.
+@export var round_counter: int = 0
+
+## Total number of turn activations processed so far.
+@export var turn_number: int = 0
+
+## Identifier for the entity currently taking its turn. Empty when idle.
+@export var active_entity_id: StringName = StringName()
+
+## Ordered roster of combatants participating in the encounter.
+@export var participants: Array[StringName] = []
+
+## Pending turn entries sorted by initiative or other scheduling logic.
+## Each dictionary is expected to contain at least `entity_id` and `initiative`
+## keys, with optional metadata for system callbacks.
+@export var turn_queue: Array[Dictionary] = []
+
+## Clears the encounter state so the resource can be reused for a fresh battle.
+func reset() -> void:
+    round_counter = 0
+    turn_number = 0
+    active_entity_id = StringName()
+    participants.clear()
+    turn_queue.clear()
+
+## Registers the combatants participating in the encounter.
+func set_participants(ids: Array[StringName]) -> void:
+    participants = ids.duplicate()
+
+## Records a new entry in the turn queue for processing by the initiative system.
+func record_turn_entry(entity_id: StringName, initiative: int, metadata: Dictionary = {}) -> void:
+    var entry: Dictionary = {
+        "entity_id": entity_id,
+        "initiative": initiative,
+    }
+    if not metadata.is_empty():
+        entry["metadata"] = metadata.duplicate(true)
+    turn_queue.append(entry)
+
+## Removes and returns the next turn entry from the queue. Updates bookkeeping to
+## reflect the active entity. Returns an empty dictionary when the queue is empty.
+func pop_next_turn() -> Dictionary:
+    if turn_queue.is_empty():
+        active_entity_id = StringName()
+        return {}
+    var next_entry: Dictionary = turn_queue.pop_front()
+    active_entity_id = next_entry.get("entity_id", StringName())
+    turn_number += 1
+    return next_entry
+
+## Returns the next queued entry without removing it. Returns an empty dictionary
+## when the queue has no entries.
+func peek_next_turn() -> Dictionary:
+    if turn_queue.is_empty():
+        return {}
+    return turn_queue[0]
+
+## Indicates whether there are any turns waiting to be processed.
+func is_queue_empty() -> bool:
+    return turn_queue.is_empty()

--- a/src/globals/ULTEnums.gd
+++ b/src/globals/ULTEnums.gd
@@ -83,6 +83,7 @@ class ComponentKeys:
     const AI_BEHAVIOR := StringName("ai_behavior")
     const FACTION := StringName("faction")
     const QUEST_STATE := StringName("quest_state")
+    const COMBAT_RUNTIME := StringName("combat_runtime")
 
     ## Returns the registered component keys as StringName values so systems can
     ## iterate without incurring temporary allocations.
@@ -96,6 +97,7 @@ class ComponentKeys:
             AI_BEHAVIOR,
             FACTION,
             QUEST_STATE,
+            COMBAT_RUNTIME,
         ]
 
     ## Returns the component keys as strings for editor drop-downs and UI lists.
@@ -139,6 +141,10 @@ const COMPONENT_KEY_METADATA := {
     ComponentKeys.QUEST_STATE: {
         "description": "QuestStateComponent tracking quest lifecycle data for an entity.",
         "resource": &"QuestStateComponent",
+    },
+    ComponentKeys.COMBAT_RUNTIME: {
+        "description": "CombatRuntimeComponent storing initiative state and timed modifiers for encounters.",
+        "resource": &"CombatRuntimeComponent",
     },
 }
 

--- a/tests/test_assets/TestDum2.tres
+++ b/tests/test_assets/TestDum2.tres
@@ -1,7 +1,14 @@
-[gd_resource type="Resource" script_class="EntityData" load_steps=3 format=3 uid="uid://bf51md0pqvkmk"]
+[gd_resource type="Resource" script_class="EntityData" load_steps=5 format=3 uid="uid://bf51md0pqvkmk"]
 
 [ext_resource type="Script" uid="uid://dkwlkfpl03j5t" path="res://src/core/EntityData.gd" id="1_leq2l"]
 [ext_resource type="Resource" uid="uid://dv0qpux18fhv1" path="res://tests/test_assets/testDum2Stat.tres" id="1_vjp57"]
+[ext_resource type="Script" path="res://src/components/CombatRuntimeComponent.gd" id="2_9rkak"]
+
+[sub_resource type="Resource" id="CombatRuntimeComponent_04jo3"]
+script = ExtResource("2_9rkak")
+base_initiative_bonus = 0
+current_initiative = 0
+initiative_modifiers = Array[Dictionary]([])
 
 [resource]
 script = ExtResource("1_leq2l")
@@ -10,6 +17,7 @@ display_name = ""
 entity_type = 1
 archetype_id = ""
 components = Dictionary[StringName, Component]({
-&"stats": ExtResource("1_vjp57")
+&"stats": ExtResource("1_vjp57"),
+&"combat_runtime": SubResource("CombatRuntimeComponent_04jo3")
 })
 metadata/_custom_type_script = "uid://dkwlkfpl03j5t"


### PR DESCRIPTION
## Summary
- add a CombatRuntimeComponent resource that tracks initiative bonuses and timed modifiers for entities
- introduce a CombatEncounterState resource to model round counters, participants, and the turn queue
- register the new component key in ULTEnums and update the TestDum2 fixture to include the runtime combat component

## Testing
- `godot4 --headless --path . --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfb4555f083209aa6fbe3dc2189da