### PR TITLE
Normalize resource metadata for headless parsing

### DIFF
--- a/assets/archetypes/README.md
+++ b/assets/archetypes/README.md
@@ -1,0 +1,3 @@
+# Archetype Assets Placeholder
+
+This directory is reserved for archetype `.tres` resources discovered by the AssetRegistry. It intentionally starts empty so tests can create fixtures without triggering missing directory warnings.

--- a/assets/entity_archetypes/Elf_TekMageEntity.tres
+++ b/assets/entity_archetypes/Elf_TekMageEntity.tres
@@ -1,9 +1,9 @@
-[gd_resource type="Resource" script_class="EntityData" load_steps=2 format=3 uid="uid://dfsri30vu4jnb"]
+[gd_resource type="Resource" script_class="EntityData" load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://rqiyylddknmy" path="res://src/core/EntityData.gd" id="2_1ro6j"]
+[ext_resource type="Script" path="res://src/core/EntityData.gd" id="1"]
 
 [resource]
-script = ExtResource("2_1ro6j")
+script = ExtResource("1")
 entity_id = ""
 display_name = ""
 entity_type = 1

--- a/assets/entity_archetypes/Elf_TekMageStats.tres
+++ b/assets/entity_archetypes/Elf_TekMageStats.tres
@@ -1,11 +1,11 @@
-[gd_resource type="Resource" script_class="StatsComponent" load_steps=3 format=3 uid="uid://ombtafnkam5a"]
+[gd_resource type="Resource" script_class="StatsComponent" load_steps=3 format=3]
 
-[ext_resource type="Script" uid="uid://bp5om06gwv0e1" path="res://src/components/StatsComponent.gd" id="1_703cd"]
-[ext_resource type="Resource" uid="uid://b4abbor4logl8" path="res://assets/entity_archetypes/Tekmage.tres" id="1_pkpp1"]
+[ext_resource type="Script" path="res://src/components/StatsComponent.gd" id="1"]
+[ext_resource type="Resource" path="res://assets/jobs/TekmageJobComponent.tres" id="2"]
 
 [resource]
-script = ExtResource("1_703cd")
-job_component = ExtResource("1_pkpp1")
+script = ExtResource("1")
+job_component = ExtResource("2")
 health = 2
 max_health = -1
 energy = 3
@@ -44,4 +44,4 @@ skill_levels = Dictionary[StringName, int]({})
 skill_options = Dictionary[StringName, Array]({})
 equipped_items = Dictionary[StringName, StringName]({})
 inventory_items = Array[StringName]([])
-metadata/_custom_type_script = "uid://dxb7uo6uqq8dx"
+metadata/_custom_type_script = "res://src/components/StatsComponent.gd"

--- a/assets/entity_archetypes/Tekmage.tres
+++ b/assets/entity_archetypes/Tekmage.tres
@@ -1,20 +1,20 @@
-[gd_resource type="Resource" script_class="Job" load_steps=6 format=3 uid="uid://b4abbor4logl8"]
+[gd_resource type="Resource" script_class="Job" load_steps=6 format=3]
 
-[ext_resource type="Script" uid="uid://bkkmosxo50ibs" path="res://assets/jobs/Job.gd" id="1_vnk5k"]
-[ext_resource type="Script" uid="uid://dvjs6e5vsppal" path="res://src/components/Skill.gd" id="2_qs7j8"]
-[ext_resource type="Script" uid="uid://bsx7tuaarx0gy" path="res://src/components/Trait.gd" id="3_wc86o"]
-[ext_resource type="Script" uid="uid://cpspnyw6i4yeh" path="res://assets/jobs/JobStatBonus.gd" id="4_xuu1f"]
-[ext_resource type="Script" uid="uid://cwx4nfi1m8tfo" path="res://assets/jobs/JobTrainingBonus.gd" id="5_pq6ou"]
+[ext_resource type="Script" path="res://assets/jobs/Job.gd" id="1"]
+[ext_resource type="Script" path="res://src/components/Skill.gd" id="2"]
+[ext_resource type="Script" path="res://src/components/Trait.gd" id="3"]
+[ext_resource type="Script" path="res://assets/jobs/JobStatBonus.gd" id="4"]
+[ext_resource type="Script" path="res://assets/jobs/JobTrainingBonus.gd" id="5"]
 
 [resource]
-script = ExtResource("1_vnk5k")
+script = ExtResource("1")
 job_id = &""
 job_title = ""
 job_pool_tags = Array[StringName]([])
-stat_bonuses = Array[ExtResource("4_xuu1f")]([null, null])
-training_bonuses = Array[ExtResource("5_pq6ou")]([])
-starting_skills = Array[ExtResource("2_qs7j8")]([])
+stat_bonuses = Array[ExtResource("4")]([null, null])
+training_bonuses = Array[ExtResource("5")]([])
+starting_skills = Array[ExtResource("2")]([])
 skill_options = Dictionary[StringName, Array]({})
-starting_traits = Array[ExtResource("3_wc86o")]([null])
+starting_traits = Array[ExtResource("3")]([null])
 formula_overrides = Dictionary[StringName, Variant]({})
-metadata/_custom_type_script = "uid://bkkmosxo50ibs"
+metadata/_custom_type_script = "res://assets/jobs/Job.gd"

--- a/assets/entity_archetypes/Test_Ent.tres
+++ b/assets/entity_archetypes/Test_Ent.tres
@@ -1,12 +1,12 @@
-[gd_resource type="Resource" script_class="EntityData" load_steps=2 format=3 uid="uid://bpucgrd5rvf30"]
+[gd_resource type="Resource" script_class="EntityData" load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://cr8f74p6cofu8" path="res://src/core/EntityData.gd" id="2_4tj6f"]
+[ext_resource type="Script" path="res://src/core/EntityData.gd" id="1"]
 
 [resource]
-script = ExtResource("2_4tj6f")
+script = ExtResource("1")
 entity_id = ""
 display_name = ""
 entity_type = 1
 archetype_id = ""
 components = Dictionary[StringName, Resource]({})
-metadata/_custom_type_script = "uid://cr8f74p6cofu8"
+metadata/_custom_type_script = "res://src/core/EntityData.gd"

--- a/assets/entity_archetypes/Test_Stat.tres
+++ b/assets/entity_archetypes/Test_Stat.tres
@@ -1,9 +1,9 @@
-[gd_resource type="Resource" script_class="StatsComponent" load_steps=2 format=3 uid="uid://c46lsnxkp8s43"]
+[gd_resource type="Resource" script_class="StatsComponent" load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://dxb7uo6uqq8dx" path="res://src/components/StatsComponent.gd" id="1_33q5k"]
+[ext_resource type="Script" path="res://src/components/StatsComponent.gd" id="1"]
 
 [resource]
-script = ExtResource("1_33q5k")
+script = ExtResource("1")
 job_component = null
 health = 0
 max_health = 0
@@ -42,4 +42,4 @@ skill_levels = Dictionary[StringName, int]({})
 skill_options = Dictionary[StringName, Array]({})
 equipped_items = Dictionary[StringName, StringName]({})
 inventory_items = Array[StringName]([])
-metadata/_custom_type_script = "uid://dxb7uo6uqq8dx"
+metadata/_custom_type_script = "res://src/components/StatsComponent.gd"

--- a/assets/jobs/Job.gd
+++ b/assets/jobs/Job.gd
@@ -1,10 +1,6 @@
 extends Resource
 class_name Job
 
-const JobStatBonus := preload("res://assets/jobs/JobStatBonus.gd")
-const JobTrainingBonus := preload("res://assets/jobs/JobTrainingBonus.gd")
-const Trait := preload("res://src/components/Trait.gd")
-const Skill := preload("res://src/components/Skill.gd")
 
 ## Data-only resource describing a modular profession or role overlay.
 ## Jobs augment baseline stats with additional bonuses, loadouts, and

--- a/assets/jobs/TekmageJobComponent.tres
+++ b/assets/jobs/TekmageJobComponent.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="JobComponent" load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://src/components/JobComponent.gd" id="1"]
+[ext_resource type="Resource" path="res://assets/entity_archetypes/Tekmage.tres" id="2"]
+
+[resource]
+script = ExtResource("1")
+primary_job = ExtResource("2")
+alternate_jobs = Array[Resource]([])
+metadata/_custom_type_script = "res://src/components/JobComponent.gd"

--- a/src/components/StatsComponent.gd
+++ b/src/components/StatsComponent.gd
@@ -6,10 +6,6 @@ class_name StatsComponent
 ## Runtime systems mutate these values in response to gameplay.
 
 const JOB_COMPONENT_SCRIPT_PATH := "res://src/components/JobComponent.gd"
-const Trait := preload("res://src/components/Trait.gd")
-const Skill := preload("res://src/components/Skill.gd")
-const JobStatBonus := preload("res://assets/jobs/JobStatBonus.gd")
-const JobTrainingBonus := preload("res://assets/jobs/JobTrainingBonus.gd")
 var _job_component_script: GDScript = null
 var _job_component_internal: Resource = null
 var _job_component_monitor: Resource = null

--- a/tests/scripts/system_testbed/CombatTimerValidator.gd
+++ b/tests/scripts/system_testbed/CombatTimerValidator.gd
@@ -672,8 +672,8 @@ func _predict_round_snapshots(round_count: int) -> Array:
 			var stats: STATS_COMPONENT_SCRIPT = context.get("stats")
 			var previous_total: int = initiative_totals.get(entity_id, 0)
 			var roll: int = rng.randi_range(1, 100)
-			var seed: int = stats.calculate_initiative_seed() if stats != null else 0
-			var total: int = roll + seed + previous_total
+			var initiative_seed: int = stats.calculate_initiative_seed() if stats != null else 0
+			var total: int = roll + initiative_seed + previous_total
 			initiative_totals[entity_id] = total
 			entries.append({
 				"entity_id": entity_id,
@@ -718,9 +718,9 @@ func _expect(condition: bool, message: String, errors: Array[String]) -> void:
 	if not condition:
 		errors.append(message)
 
-func _build_result(name: String, errors: Array[String]) -> Dictionary:
+func _build_result(label: String, errors: Array[String]) -> Dictionary:
 	return {
-		"name": name,
+		"name": label,
 		"passed": errors.is_empty(),
 		"errors": errors,
 	}

--- a/tests/scripts/system_testbed/StatusSystemValidator.gd
+++ b/tests/scripts/system_testbed/StatusSystemValidator.gd
@@ -275,8 +275,6 @@ func _validate_long_term_lifecycle(
 	var stats: STATS_COMPONENT_SCRIPT = context.get("stats")
 	var status_component: STATUS_COMPONENT_SCRIPT = context.get("status_component")
 	var entity_data: ENTITY_DATA_SCRIPT = context.get("entity_data")
-	var entity: ENTITY_SCRIPT = context.get("entity")
-
 	var effect := STATUS_FX_SCRIPT.new()
 	effect.effect_name = LONG_TERM_EFFECT_NAME
 	effect.is_passive = false

--- a/tests/test_assets/TestDum2.tres
+++ b/tests/test_assets/TestDum2.tres
@@ -1,23 +1,23 @@
-[gd_resource type="Resource" script_class="EntityData" load_steps=5 format=3 uid="uid://bf51md0pqvkmk"]
+[gd_resource type="Resource" script_class="EntityData" load_steps=5 format=3]
 
-[ext_resource type="Script" uid="uid://oarq6t337b4f" path="res://src/core/EntityData.gd" id="1_leq2l"]
-[ext_resource type="Resource" uid="uid://dv0qpux18fhv1" path="res://tests/test_assets/testDum2Stat.tres" id="1_vjp57"]
-[ext_resource type="Script" uid="uid://dg78gmwbt4v15" path="res://src/components/CombatRuntimeComponent.gd" id="2_9rkak"]
+[ext_resource type="Script" path="res://src/core/EntityData.gd" id="1"]
+[ext_resource type="Resource" path="res://tests/test_assets/testDum2Stat.tres" id="2"]
+[ext_resource type="Script" path="res://src/components/CombatRuntimeComponent.gd" id="3"]
 
 [sub_resource type="Resource" id="CombatRuntimeComponent_04jo3"]
-script = ExtResource("2_9rkak")
+script = ExtResource("3")
 base_initiative_bonus = 0
 current_initiative = 0
 initiative_modifiers = Array[Dictionary]([])
 
 [resource]
-script = ExtResource("1_leq2l")
+script = ExtResource("1")
 entity_id = ""
 display_name = ""
 entity_type = 1
 archetype_id = ""
 components = Dictionary[StringName, Resource]({
 &"combat_runtime": SubResource("CombatRuntimeComponent_04jo3"),
-&"stats": ExtResource("1_vjp57")
+&"stats": ExtResource("2")
 })
-metadata/_custom_type_script = "uid://dkwlkfpl03j5t"
+metadata/_custom_type_script = "res://src/core/EntityData.gd"

--- a/tests/test_assets/testDum2Stat.tres
+++ b/tests/test_assets/testDum2Stat.tres
@@ -1,9 +1,9 @@
-[gd_resource type="Resource" script_class="StatsComponent" load_steps=2 format=3 uid="uid://dv0qpux18fhv1"]
+[gd_resource type="Resource" script_class="StatsComponent" load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://csvd6qtj05xe0" path="res://src/components/StatsComponent.gd" id="1_x10rm"]
+[ext_resource type="Script" path="res://src/components/StatsComponent.gd" id="1"]
 
 [resource]
-script = ExtResource("1_x10rm")
+script = ExtResource("1")
 job_component = null
 health = 100
 max_health = 0
@@ -42,4 +42,4 @@ skill_levels = Dictionary[StringName, int]({})
 skill_options = Dictionary[StringName, Array]({})
 equipped_items = Dictionary[StringName, StringName]({})
 inventory_items = Array[StringName]([])
-metadata/_custom_type_script = "uid://csvd6qtj05xe0"
+metadata/_custom_type_script = "res://src/components/StatsComponent.gd"


### PR DESCRIPTION
## Summary
- remove redundant preloads in StatsComponent and Job scripts to silence class name shadow warnings during parsing
- update sample entity and job resources to use path-based ext_resources, add a Tekmage JobComponent wrapper, and create an archetype directory placeholder to clear UID and missing directory warnings
- clean up validator scripts by renaming the initiative seed variable and avoiding Node.name shadowing

## Testing
- timeout 10 godot4 --headless --path . --check-only

------
https://chatgpt.com/codex/tasks/task_e_68dc43e62c1c8320aff4ae071095a4d7